### PR TITLE
remove Option type for pool on `Conn`

### DIFF
--- a/src/conn.rs
+++ b/src/conn.rs
@@ -20,23 +20,12 @@ pub type ConnFuture<T, E> =
 /// also implements `Service` itself by delegating.
 #[derive(Debug)]
 pub struct Conn<C: ManageConnection> {
+    /// Actual connection. This should never become a None variant under normal operation.
+    /// This is an option so we can take the connection on drop, and push it back into the pool
     pub conn: Option<Live<C::Connection>>,
-    // In a normal case this is always Some, but it can be none if constructed from the
-    // new_unpooled constructor.
-    pub pool: Option<Arc<ConnectionPool<C>>>,
-}
-
-impl<C: ManageConnection> Conn<C> {
-    /// This constructor creates a connection which is not stored in a thread
-    /// pool. It can be useful for purposes in which you need to treat a
-    /// non-pooled connection as if it were stored in a pool, such as during
-    /// tests.
-    pub fn new_unpooled(connection: C::Connection) -> Self {
-        Conn {
-            conn: Some(Live::new(connection)),
-            pool: None,
-        }
-    }
+    /// Underlying pool. A reference is stored here so we can push the connection back into the
+    /// pool on drop
+    pub pool: Arc<ConnectionPool<C>>,
 }
 
 impl<C: ManageConnection> Deref for Conn<C> {
@@ -55,7 +44,7 @@ impl<C: ManageConnection> DerefMut for Conn<C> {
 impl<C: ManageConnection> Drop for Conn<C> {
     fn drop(&mut self) {
         let conn = self.conn.take().unwrap();
-        self.pool.as_ref().map(|pool| pool.store(conn));
+        self.pool.store(conn);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ impl<C: ManageConnection> Pool<C> {
         if let Some(conn) = self.conn_pool.get_connection() {
             future::Either::A(future::ok(Conn {
                 conn: Some(conn),
-                pool: Some(Arc::clone(&self.conn_pool)),
+                pool: Arc::clone(&self.conn_pool),
             }))
         } else {
             //Have the pool notify us of the connection
@@ -77,7 +77,7 @@ impl<C: ManageConnection> Pool<C> {
             future::Either::B(Box::new(
                 rx.map(|conn| Conn {
                     conn: Some(conn),
-                    pool: Some(pool),
+                    pool: pool,
                 }).map_err(|_err| unimplemented!()),
             ))
         }


### PR DESCRIPTION
This was part of the struct in c3po, but having an option just to make
testing eaiser isn't great ergonomics.