### PR TITLE
unfork postgres

### DIFF
--- a/l337-postgres/Cargo.toml
+++ b/l337-postgres/Cargo.toml
@@ -7,5 +7,5 @@ authors = ["Jonathon Sheffield <samsmug@gmail.com>"]
 l3-37 = { path = ".." }
 futures = "0.1.14"
 tokio = "0.1.8"
-tokio-postgres = { git = "https://github.com/Cohedrin/rust-postgres.git", rev = "cf5765ea353aa22481c104e3e3b7cc83dffb95f9"}
-postgres-shared = { git = "https://github.com/Cohedrin/rust-postgres.git", rev = "cf5765ea353aa22481c104e3e3b7cc83dffb95f9" }
+tokio-postgres = { git = "https://github.com/sfackler/rust-postgres.git" }
+postgres-shared = { git = "https://github.com/sfackler/rust-postgres.git" }


### PR DESCRIPTION
There's no need to fork postgres, that was for debugging purposes. This
switches us back to the mainline version