### PR TITLE
Use 'dyn' since trait objects without an explicit 'dyn' are deprecated

### DIFF
--- a/src/conn.rs
+++ b/src/conn.rs
@@ -48,7 +48,7 @@ use Pool;
 
 /// Connection future
 pub type ConnFuture<T, E> =
-    future::Either<future::FutureResult<T, E>, Box<Future<Item = T, Error = E> + Send>>;
+    future::Either<future::FutureResult<T, E>, Box<dyn Future<Item = T, Error = E> + Send>>;
 
 // From c3po, https://github.com/withoutboats/c3po/blob/08a6fde00c6506bacfe6eebe621520ee54b418bb/src/lib.rs#L40
 

--- a/src/inner.rs
+++ b/src/inner.rs
@@ -79,7 +79,7 @@ impl<C: ManageConnection> ConnectionPool<C> {
         self.config.max_size
     }
 
-    pub fn connect(&self) -> Box<Future<Item = C::Connection, Error = Error<C::Error>> + Send> {
+    pub fn connect(&self) -> Box<dyn Future<Item = C::Connection, Error = Error<C::Error>> + Send> {
         self.manager.connect()
     }
 

--- a/src/manage_connection.rs
+++ b/src/manage_connection.rs
@@ -39,7 +39,7 @@ pub trait ManageConnection: Send + Sync + 'static {
     /// within trait definitions.
     fn connect(
         &self,
-    ) -> Box<Future<Item = Self::Connection, Error = L337Error<Self::Error>> + 'static + Send>;
+    ) -> Box<dyn Future<Item = Self::Connection, Error = L337Error<Self::Error>> + 'static + Send>;
 
     /// Determines if the connection is still connected to the database.
     ///
@@ -48,7 +48,7 @@ pub trait ManageConnection: Send + Sync + 'static {
     fn is_valid(
         &self,
         conn: Self::Connection,
-    ) -> Box<Future<Item = (), Error = L337Error<Self::Error>>>;
+    ) -> Box<dyn Future<Item = (), Error = L337Error<Self::Error>>>;
 
     /// Quick check to determine if the connection has broken
     fn has_broken(&self, conn: &mut Self::Connection) -> bool;


### PR DESCRIPTION
closes #27 