### PR TITLE
chore: bump version

### DIFF
--- a/l337-postgres/Cargo.toml
+++ b/l337-postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "l337-postgres"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Jonathon Sheffield <samsmug@gmail.com>"]
 
 [dependencies]


### PR DESCRIPTION
It is easier to tell in users' projects if this library has been updated
to a include the improved connection Drop impl if the version number is
increased.