### PR TITLE
Only spawn connection loop future if there are waiters

### DIFF
--- a/src/inner.rs
+++ b/src/inner.rs
@@ -89,6 +89,10 @@ impl<C: ManageConnection> ConnectionPool<C> {
         self.waiting.push(tx);
     }
 
+    pub fn has_waiting(&self) -> bool {
+        !self.waiting.is_empty()
+    }
+
     pub fn try_waiting(
         &self,
     ) -> Option<oneshot::Sender<Live<<C as ManageConnection>::Connection>>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,7 +244,11 @@ impl<C: ManageConnection + Send> Pool<C> {
         if broken {
             conns.decrement();
             debug!("connection count is now: {:?}", conns.total());
-            self.spawn_new_future_loop();
+            // Spawn a future to grab a new connection if there is
+            // someone waiting for a new connection.
+            if self.conn_pool.has_waiting() {
+                self.spawn_new_future_loop();
+            }
             return;
         }
 


### PR DESCRIPTION
This helps in the testing case where we might drop a connection 
in a non-future context, which shouldn't need to spawn a future + panic.