### PR TITLE
Futures 03

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker: # use the docker executor type; machine and macos executors are also supported
-      - image: circleci/rust:1.34
+      - image: circleci/rust:1.39
       - image: redis:4.0.1
         name: redis
       - image: "sfackler/rust-postgres-test:4"
@@ -12,12 +12,12 @@ jobs:
       - checkout # check out the code in the project directory
       - restore_cache:
           keys:
-            - target-v1-{{ .Branch }}-{{ checksum "Cargo.toml" }}
-            - target-v1-master-
-            - target-v1-
+            - target-v2-{{ .Branch }}-{{ checksum "Cargo.toml" }}
+            - target-v2-master-
+            - target-v2-
       - run: cargo build --release --all
       - run: cargo test --all
       - save_cache:
-          key: target-v1-{{ .Branch }}-{{ checksum "Cargo.toml" }}
+          key: target-v2-{{ .Branch }}-{{ checksum "Cargo.toml" }}
           paths:
             - target/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker: # use the docker executor type; machine and macos executors are also supported
-      - image: circleci/rust:1.39
+      - image: circleci/rust:1.40
       - image: redis:4.0.1
         name: redis
       - image: "sfackler/rust-postgres-test:4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 futures = "0.3"
 tokio = { version = "0.2", features = ["rt-core", "time"] }
-crossbeam = "0.4"
+crossbeam-queue = "0.2"
 failure = "0.1.2"
 log = "0.4"
 async-trait = "0.1.22"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,14 +8,17 @@ edition = "2018"
 
 [dependencies]
 futures = "0.3"
-tokio = { version = "0.2", features = ["full"] }
+tokio = { version = "0.2", features = ["rt-core", "time"] }
 crossbeam = "0.4"
 failure = "0.1.2"
 log = "0.4"
-async-trait = "0.1.18"
+async-trait = "0.1.22"
 
 [workspace]
 members = [
   "l337-postgres",
   "l337-redis"
 ]
+
+[dev-dependencies]
+tokio = { version = "0.2", features = ["macros", "rt-core", "time"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,13 +4,15 @@ version = "0.0.0"
 authors = ["Jonathon Sheffield <samsmug@gmail.com>", "Joe Wilm <joe@jwilm.com>"]
 license = "MIT OR Apache-2.0"
 description = "yet another connection pooler"
+edition = "2018"
 
 [dependencies]
-futures = "0.1.14"
-tokio = "0.1.8"
+futures = "0.3"
+tokio = { version = "0.2", features = ["full"] }
 crossbeam = "0.4"
 failure = "0.1.2"
 log = "0.4"
+async-trait = "0.1.18"
 
 [workspace]
 members = [

--- a/l337-postgres/Cargo.toml
+++ b/l337-postgres/Cargo.toml
@@ -2,10 +2,12 @@
 name = "l337-postgres"
 version = "0.2.0"
 authors = ["Jonathon Sheffield <samsmug@gmail.com>"]
+edition = "2018"
 
 [dependencies]
 l337 = { path = ".." }
-futures = "0.1.14"
-tokio = "0.1.8"
-tokio-postgres = "0.4.0-rc.2"
+futures = "0.3"
+tokio = "0.2"
+tokio-postgres = "0.5.0-alpha.2"
 log = "0.4.8"
+async-trait = "0.1.18"

--- a/l337-postgres/Cargo.toml
+++ b/l337-postgres/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2018"
 l337 = { path = ".." }
 futures = "0.3"
 tokio = "0.2"
-tokio-postgres = "0.5.0-alpha.2"
+tokio-postgres = "0.5.1"
 log = "0.4.8"
-async-trait = "0.1.18"
+async-trait = "0.1.22"

--- a/l337-postgres/Cargo.toml
+++ b/l337-postgres/Cargo.toml
@@ -11,3 +11,6 @@ tokio = "0.2"
 tokio-postgres = "0.5.1"
 log = "0.4.8"
 async-trait = "0.1.22"
+
+[dev-dependencies]
+tokio = { version = "0.2", features = ["macros"] }

--- a/l337-postgres/src/lib.rs
+++ b/l337-postgres/src/lib.rs
@@ -218,7 +218,6 @@ mod tests {
             tokio_postgres::NoTls,
         );
 
-
         let config: Config = Default::default();
         let pool = Pool::new(mngr, config).await.unwrap();
         let q1 = async {

--- a/l337-postgres/src/lib.rs
+++ b/l337-postgres/src/lib.rs
@@ -8,10 +8,11 @@ pub extern crate tokio_postgres;
 
 #[macro_use]
 extern crate log;
+#[macro_use]
+extern crate async_trait;
 
-use futures::sync::oneshot;
-use futures::{Async, Future, Stream};
-use tokio::executor::spawn;
+use futures::channel::oneshot;
+use tokio::spawn;
 use tokio_postgres::error::Error;
 use tokio_postgres::{
     tls::{MakeTlsConnect, TlsConnect},
@@ -48,6 +49,7 @@ where
     }
 }
 
+#[async_trait]
 impl<T> l337::ManageConnection for PostgresConnectionManager<T>
 where
     T: 'static + MakeTlsConnect<Socket> + Clone + Send + Sync,
@@ -58,42 +60,37 @@ where
     type Connection = AsyncConnection;
     type Error = Error;
 
-    fn connect(
-        &self,
-    ) -> Box<Future<Item = Self::Connection, Error = l337::Error<Self::Error>> + 'static + Send>
-    {
-        Box::new(
-            self.config
-                .connect(self.make_tls_connect.clone())
-                .map(|(client, connection)| {
-                    let (sender, receiver) = oneshot::channel();
-                    spawn(connection.map_err(|_| {
-                        sender
-                            .send(true)
-                            .unwrap_or_else(|e| panic!("failed to send shutdown notice: {}", e));
-                    }));
-                    AsyncConnection {
-                        broken: false,
-                        client,
-                        receiver,
-                    }
-                })
-                .map_err(|e| l337::Error::External(e)),
-        )
+    async fn connect(&self) -> Result<Self::Connection, l337::Error<Self::Error>> {
+        let (client, connection) = self
+            .config
+            .connect(self.make_tls_connect.clone())
+            .await
+            .map_err(|e| l337::Error::External(e))?;
+
+        let (sender, receiver) = oneshot::channel();
+        spawn(async move {
+            if let Err(_) = connection.await {
+                sender
+                    .send(true)
+                    .unwrap_or_else(|e| panic!("failed to send shutdown notice: {}", e));
+            }
+        });
+
+        Ok(AsyncConnection {
+            broken: false,
+            client,
+            receiver,
+        })
     }
 
-    fn is_valid(
-        &self,
-        mut conn: Self::Connection,
-    ) -> Box<Future<Item = (), Error = l337::Error<Self::Error>>> {
+    async fn is_valid(&self, conn: Self::Connection) -> Result<(), l337::Error<Self::Error>> {
         // If we can execute this without erroring, we're definitely still connected to the database
-        Box::new(
-            conn.client
-                .simple_query("")
-                .into_future()
-                .map(|_| ())
-                .map_err(|(e, _)| l337::Error::External(e)),
-        )
+        conn.client
+            .simple_query("")
+            .await
+            .map_err(|e| l337::Error::External(e))?;
+
+        Ok(())
     }
 
     fn has_broken(&self, conn: &mut Self::Connection) -> bool {
@@ -144,14 +141,12 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use futures::Stream;
     use l337::{Config, Pool};
-    use std::thread::sleep;
     use std::time::Duration;
-    use tokio::runtime::current_thread::Runtime;
+    use tokio::time::delay_for;
 
-    #[test]
-    fn it_works() {
+    #[tokio::test]
+    async fn it_works() {
         let mngr = PostgresConnectionManager::new(
             "postgres://pass_user:password@localhost:5433/postgres"
                 .parse()
@@ -159,28 +154,20 @@ mod tests {
             tokio_postgres::NoTls,
         );
 
-        let mut runtime = Runtime::new().expect("could not run");
         let config: Config = Default::default();
-        let future = Pool::new(mngr, config).and_then(|pool| {
-            pool.connection().and_then(|mut conn| {
-                conn.client
-                    .prepare("SELECT 1::INT4")
-                    .and_then(move |select| {
-                        conn.client.query(&select, &[]).for_each(|row| {
-                            assert_eq!(1, row.get::<_, i32>(0));
-                            Ok(())
-                        })
-                    })
-                    .map(|connection| ((), connection))
-                    .map_err(|e| l337::Error::External(e))
-            })
-        });
+        let pool = Pool::new(mngr, config).await.unwrap();
+        let conn = pool.connection().await.unwrap();
+        let select = conn.client.prepare("SELECT 1::INT4").await.unwrap();
 
-        runtime.block_on(future).expect("could not run");
+        let rows = conn.client.query(&select, &[]).await.unwrap();
+
+        for row in rows {
+            assert_eq!(1, row.get(0));
+        }
     }
 
-    #[test]
-    fn it_allows_multiple_queries_at_the_same_time() {
+    #[tokio::test]
+    async fn it_allows_multiple_queries_at_the_same_time() {
         let mngr = PostgresConnectionManager::new(
             "postgres://pass_user:password@localhost:5433/postgres"
                 .parse()
@@ -188,49 +175,42 @@ mod tests {
             tokio_postgres::NoTls,
         );
 
-        let mut runtime = Runtime::new().expect("could not run");
         let config: Config = Default::default();
-        let future = Pool::new(mngr, config).and_then(|pool| {
-            let q1 = pool.connection().and_then(|mut conn| {
-                conn.client
-                    .prepare("SELECT 1::INT4")
-                    .and_then(move |select| {
-                        conn.client.query(&select, &[]).for_each(|row| {
-                            assert_eq!(1, row.get::<_, i32>(0));
-                            Ok(())
-                        })
-                    })
-                    .map(|connection| {
-                        sleep(Duration::from_secs(5));
-                        ((), connection)
-                    })
-                    .map_err(|e| l337::Error::External(e))
-            });
+        let pool = Pool::new(mngr, config).await.unwrap();
 
-            let q2 = pool.connection().and_then(|mut conn| {
-                conn.client
-                    .prepare("SELECT 2::INT4")
-                    .and_then(move |select| {
-                        conn.client.query(&select, &[]).for_each(|row| {
-                            assert_eq!(2, row.get::<_, i32>(0));
-                            Ok(())
-                        })
-                    })
-                    .map(|connection| {
-                        sleep(Duration::from_secs(5));
-                        ((), connection)
-                    })
-                    .map_err(|e| l337::Error::External(e))
-            });
+        let q1 = async {
+            let conn = pool.connection().await.unwrap();
+            let select = conn.client.prepare("SELECT 1::INT4").await.unwrap();
+            let rows = conn.client.query(&select, &[]).await.unwrap();
 
-            q1.join(q2)
-        });
+            for row in rows {
+                assert_eq!(1, row.get(0));
+            }
 
-        runtime.block_on(future).expect("could not run");
+            delay_for(Duration::from_secs(5)).await;
+
+            conn
+        };
+
+        let q2 = async {
+            let conn = pool.connection().await.unwrap();
+            let select = conn.client.prepare("SELECT 2::INT4").await.unwrap();
+            let rows = conn.client.query(&select, &[]).await.unwrap();
+
+            for row in rows {
+                assert_eq!(2, row.get(0));
+            }
+
+            delay_for(Duration::from_secs(5)).await;
+
+            conn
+        };
+
+        futures::join!(q1, q2);
     }
 
-    #[test]
-    fn it_reuses_connections() {
+    #[tokio::test]
+    async fn it_reuses_connections() {
         let mngr = PostgresConnectionManager::new(
             "postgres://pass_user:password@localhost:5433/postgres"
                 .parse()
@@ -238,60 +218,51 @@ mod tests {
             tokio_postgres::NoTls,
         );
 
-        let mut runtime = Runtime::new().expect("could not run");
+
         let config: Config = Default::default();
-        let future = Pool::new(mngr, config).and_then(|pool| {
-            let q1 = pool.connection().and_then(|mut conn| {
-                conn.client
-                    .prepare("SELECT 1::INT4")
-                    .and_then(move |select| {
-                        conn.client.query(&select, &[]).for_each(|row| {
-                            assert_eq!(1, row.get::<_, i32>(0));
-                            Ok(())
-                        })
-                    })
-                    .map(|connection| {
-                        sleep(Duration::from_secs(5));
-                        ((), connection)
-                    })
-                    .map_err(|e| l337::Error::External(e))
-            });
+        let pool = Pool::new(mngr, config).await.unwrap();
+        let q1 = async {
+            let conn = pool.connection().await.unwrap();
+            let select = conn.client.prepare("SELECT 1::INT4").await.unwrap();
+            let rows = conn.client.query(&select, &[]).await.unwrap();
 
-            let q2 = pool.connection().and_then(|mut conn| {
-                conn.client
-                    .prepare("SELECT 2::INT4")
-                    .and_then(move |select| {
-                        conn.client.query(&select, &[]).for_each(|row| {
-                            assert_eq!(2, row.get::<_, i32>(0));
-                            Ok(())
-                        })
-                    })
-                    .map(|connection| {
-                        sleep(Duration::from_secs(5));
-                        ((), connection)
-                    })
-                    .map_err(|e| l337::Error::External(e))
-            });
+            for row in rows {
+                assert_eq!(1, row.get(0));
+            }
 
-            let q3 = pool.connection().and_then(|mut conn| {
-                conn.client
-                    .prepare("SELECT 3::INT4")
-                    .and_then(move |select| {
-                        conn.client.query(&select, &[]).for_each(|row| {
-                            assert_eq!(3, row.get::<_, i32>(0));
-                            Ok(())
-                        })
-                    })
-                    .map(|connection| {
-                        sleep(Duration::from_secs(5));
-                        ((), connection)
-                    })
-                    .map_err(|e| l337::Error::External(e))
-            });
+            delay_for(Duration::from_secs(5)).await;
 
-            q1.join3(q2, q3)
-        });
+            conn
+        };
 
-        runtime.block_on(future).expect("could not run");
+        let q2 = async {
+            let conn = pool.connection().await.unwrap();
+            let select = conn.client.prepare("SELECT 2::INT4").await.unwrap();
+            let rows = conn.client.query(&select, &[]).await.unwrap();
+
+            for row in rows {
+                assert_eq!(2, row.get(0));
+            }
+
+            delay_for(Duration::from_secs(5)).await;
+
+            conn
+        };
+
+        let q3 = async {
+            let conn = pool.connection().await.unwrap();
+            let select = conn.client.prepare("SELECT 3::INT4").await.unwrap();
+            let rows = conn.client.query(&select, &[]).await.unwrap();
+
+            for row in rows {
+                assert_eq!(3, row.get(0));
+            }
+
+            delay_for(Duration::from_secs(5)).await;
+
+            conn
+        };
+
+        futures::join!(q1, q2, q3);
     }
 }

--- a/l337-postgres/src/lib.rs
+++ b/l337-postgres/src/lib.rs
@@ -83,7 +83,7 @@ where
         })
     }
 
-    async fn is_valid(&self, conn: Self::Connection) -> Result<(), l337::Error<Self::Error>> {
+    async fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), l337::Error<Self::Error>> {
         // If we can execute this without erroring, we're definitely still connected to the database
         conn.client
             .simple_query("")

--- a/l337-postgres/src/lib.rs
+++ b/l337-postgres/src/lib.rs
@@ -98,9 +98,9 @@ where
             return true;
         }
 
-        // Use try_recv() as `has_broken` can be called via Drop
-        // and not have a future Context to poll on.
-        // https://docs.rs/futures/0.1.28/futures/sync/oneshot/struct.Receiver.html#method.try_recv
+        // Use try_recv() as `has_broken` can be called via Drop and not have a
+        // future Context to poll on.
+        // https://docs.rs/futures/0.3.1/futures/channel/oneshot/struct.Receiver.html#method.try_recv
         match conn.receiver.try_recv() {
             // If we get any message, the connection task stopped, which means this connection is
             // now dead

--- a/l337-redis/Cargo.toml
+++ b/l337-redis/Cargo.toml
@@ -8,8 +8,7 @@ edition = "2018"
 l337 = { path = ".." }
 futures = "0.3"
 tokio = "0.2"
-# This should be changed to the next version of redis-rs when
-# https://github.com/mitsuhiko/redis-rs/pull/232 is merged.
-redis = { git = "https://github.com/Marwes/redis-rs.git", branch = "async_await_api" }
-async-trait = "0.1.18"
+# This should be changed to the next version of redis-rs when a release is done.
+redis = { git = "https://github.com/mitsuhiko/redis-rs.git", branch = "master" }
+async-trait = "0.1.22"
 log = "0.4"

--- a/l337-redis/Cargo.toml
+++ b/l337-redis/Cargo.toml
@@ -2,9 +2,11 @@
 name = "l337-redis"
 version = "0.1.0"
 authors = ["Jonathon Sheffield <samsmug@gmail.com>"]
+edition = "2018"
 
 [dependencies]
 l337 = { path = ".." }
-futures = "0.1.14"
-tokio = "0.1.8"
+futures = "0.3"
+tokio = "0.2"
 redis = "0.13"
+async-trait = "0.1.18"

--- a/l337-redis/Cargo.toml
+++ b/l337-redis/Cargo.toml
@@ -8,7 +8,10 @@ edition = "2018"
 l337 = { path = ".." }
 futures = "0.3"
 tokio = "0.2"
-# This should be changed to the next version of redis-rs when a release is done.
-redis = { git = "https://github.com/mitsuhiko/redis-rs.git", branch = "master" }
+redis = "0.14.0"
 async-trait = "0.1.22"
 log = "0.4"
+
+[dev-dependencies]
+# Required for the #[tokio::test] macro
+tokio = { version = "0.2", features = ["rt-core", "macros"] }

--- a/l337-redis/Cargo.toml
+++ b/l337-redis/Cargo.toml
@@ -8,5 +8,8 @@ edition = "2018"
 l337 = { path = ".." }
 futures = "0.3"
 tokio = "0.2"
-redis = "0.13"
+# This should be changed to the next version of redis-rs when
+# https://github.com/mitsuhiko/redis-rs/pull/232 is merged.
+redis = { git = "https://github.com/Marwes/redis-rs.git", branch = "async_await_api" }
 async-trait = "0.1.18"
+log = "0.4"

--- a/l337-redis/src/lib.rs
+++ b/l337-redis/src/lib.rs
@@ -146,8 +146,11 @@ mod tests {
         let config: Config = Default::default();
 
         let pool = Pool::new(mngr, config).await.unwrap();
-        let conn: &mut AsyncConnection = &mut pool.connection().await.unwrap();
-        redis::cmd("PING").query_async::<_, ()>(conn).await.unwrap();
+        let mut conn = pool.connection().await.unwrap();
+        redis::cmd("PING")
+            .query_async::<_, ()>(&mut *conn)
+            .await
+            .unwrap();
 
         println!("done ping")
     }

--- a/l337-redis/src/lib.rs
+++ b/l337-redis/src/lib.rs
@@ -103,7 +103,7 @@ mod tests {
 
     #[tokio::test]
     async fn it_works() {
-        let mngr = RedisConnectionManager::new("redis://localhost:6379/0").unwrap();
+        let mngr = RedisConnectionManager::new("redis://redis:6379/0").unwrap();
 
         let config: Config = Default::default();
 

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -39,7 +39,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use futures::future::{self, Future};
 use std::ops::{Deref, DerefMut};
 
 use crate::manage_connection::ManageConnection;

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -59,7 +59,11 @@ pub type ConnFuture<T, E> = future::Either<
 ///
 /// This can be dereferences to the `Service` instance this pool manages, and
 /// also implements `Service` itself by delegating.
-pub struct Conn<C> where C: ManageConnection, C::Connection: Send {
+pub struct Conn<C>
+where
+    C: ManageConnection,
+    C::Connection: Send,
+{
     /// Actual connection. This should never become a None variant under normal operation.
     /// This is an option so we can take the connection on drop, and push it back into the pool
     pub conn: Option<Live<C::Connection>>,
@@ -71,25 +75,39 @@ pub struct Conn<C> where C: ManageConnection, C::Connection: Send {
     pub pool: Option<Pool<C>>,
 }
 
-impl<C> Deref for Conn<C> where C: ManageConnection, C::Connection: Send{
+impl<C> Deref for Conn<C>
+where
+    C: ManageConnection,
+    C::Connection: Send,
+{
     type Target = C::Connection;
     fn deref(&self) -> &Self::Target {
         &self.conn.as_ref().unwrap().conn
     }
 }
 
-impl<C> DerefMut for Conn<C> where C: ManageConnection, C::Connection: Send{
+impl<C> DerefMut for Conn<C>
+where
+    C: ManageConnection,
+    C::Connection: Send,
+{
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.conn.as_mut().unwrap().conn
     }
 }
 
-impl<C> Drop for Conn<C> where C: ManageConnection, C::Connection: Send{
+impl<C> Drop for Conn<C>
+where
+    C: ManageConnection,
+    C::Connection: Send,
+{
     fn drop(&mut self) {
         let conn = self.conn.take().unwrap();
         let pool = self.pool.take().unwrap();
 
-        tokio::spawn(async move {pool.put_back(conn).await;});
+        tokio::spawn(async move {
+            pool.put_back(conn).await;
+        });
     }
 }
 

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -46,12 +46,6 @@ use crate::manage_connection::ManageConnection;
 use crate::queue::Live;
 use crate::Pool;
 
-/// Connection future
-pub type ConnFuture<T, E> = future::Either<
-    Result<T, E>,
-    std::pin::Pin<Box<dyn Future<Output = Result<T, E>> + Send + Unpin>>,
->;
-
 // From c3po, https://github.com/withoutboats/c3po/blob/08a6fde00c6506bacfe6eebe621520ee54b418bb/src/lib.rs#L40
 
 /// A smart wrapper around a connection which stores it back in the pool

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -42,13 +42,15 @@
 use futures::future::{self, Future};
 use std::ops::{Deref, DerefMut};
 
-use manage_connection::ManageConnection;
-use queue::Live;
-use Pool;
+use crate::manage_connection::ManageConnection;
+use crate::queue::Live;
+use crate::Pool;
 
 /// Connection future
-pub type ConnFuture<T, E> =
-    future::Either<future::FutureResult<T, E>, Box<dyn Future<Item = T, Error = E> + Send>>;
+pub type ConnFuture<T, E> = future::Either<
+    Result<T, E>,
+    std::pin::Pin<Box<dyn Future<Output = Result<T, E>> + Send + Unpin>>,
+>;
 
 // From c3po, https://github.com/withoutboats/c3po/blob/08a6fde00c6506bacfe6eebe621520ee54b418bb/src/lib.rs#L40
 
@@ -57,67 +59,62 @@ pub type ConnFuture<T, E> =
 ///
 /// This can be dereferences to the `Service` instance this pool manages, and
 /// also implements `Service` itself by delegating.
-pub struct Conn<C: ManageConnection> {
+pub struct Conn<C> where C: ManageConnection, C::Connection: Send {
     /// Actual connection. This should never become a None variant under normal operation.
     /// This is an option so we can take the connection on drop, and push it back into the pool
     pub conn: Option<Live<C::Connection>>,
-    /// Underlying pool. A reference is stored here so we can push the connection back into the
-    /// pool on drop
-    pub pool: Pool<C>,
+
+    /// Underlying pool. A reference is stored here so we can push the connection
+    /// back into the pool on drop. This should never become a None variant under
+    /// normal operation. This is an option so we can take the connection on
+    /// drop, and push it back into the pool
+    pub pool: Option<Pool<C>>,
 }
 
-impl<C: ManageConnection> Deref for Conn<C> {
+impl<C> Deref for Conn<C> where C: ManageConnection, C::Connection: Send{
     type Target = C::Connection;
     fn deref(&self) -> &Self::Target {
         &self.conn.as_ref().unwrap().conn
     }
 }
 
-impl<C: ManageConnection> DerefMut for Conn<C> {
+impl<C> DerefMut for Conn<C> where C: ManageConnection, C::Connection: Send{
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.conn.as_mut().unwrap().conn
     }
 }
 
-impl<C: ManageConnection> Drop for Conn<C> {
+impl<C> Drop for Conn<C> where C: ManageConnection, C::Connection: Send{
     fn drop(&mut self) {
         let conn = self.conn.take().unwrap();
-        self.pool.put_back(conn);
+        let pool = self.pool.take().unwrap();
+
+            tokio::spawn(async move {pool.put_back(conn).await;});
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tests::DummyManager;
-    use tokio::runtime::current_thread::Runtime;
-    use Config;
-    use Pool;
+    use crate::tests::DummyManager;
+    use crate::Config;
 
-    #[test]
-    fn conn_pushes_back_into_pool_after_drop() {
+    #[tokio::test]
+    async fn conn_pushes_back_into_pool_after_drop() {
         let mngr = DummyManager {};
         let config = Config {
             min_size: 2,
             max_size: 2,
         };
 
-        let future = Pool::new(mngr, config).and_then(|pool| {
-            assert_eq!(pool.idle_conns(), 2);
+        let pool = Pool::new(mngr, config).await.unwrap();
+        assert_eq!(pool.idle_conns().await, 2);
 
-            pool.connection().and_then(move |conn| {
-                assert_eq!(pool.idle_conns(), 1);
+        let conn = pool.connection().await.unwrap();
+        assert_eq!(pool.idle_conns().await, 1);
 
-                ::std::mem::drop(conn);
+        ::std::mem::drop(conn);
 
-                assert_eq!(pool.idle_conns(), 2);
-                Ok(())
-            })
-        });
-
-        Runtime::new()
-            .expect("could not run")
-            .block_on(future)
-            .expect("could not run");
+        assert_eq!(pool.idle_conns().await, 2);
     }
 }

--- a/src/inner.rs
+++ b/src/inner.rs
@@ -40,7 +40,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crossbeam::queue::SegQueue;
+use crossbeam_queue::SegQueue;
 use futures::channel::oneshot;
 use futures::lock::Mutex;
 use std::sync::Arc;
@@ -92,7 +92,7 @@ impl<C: ManageConnection> ConnectionPool<C> {
     pub fn try_waiting(
         &self,
     ) -> Option<oneshot::Sender<Live<<C as ManageConnection>::Connection>>> {
-        self.waiting.try_pop()
+        self.waiting.pop().ok()
     }
 
     pub fn has_broken(&self, conn: &mut Live<C::Connection>) -> bool {

--- a/src/inner.rs
+++ b/src/inner.rs
@@ -41,14 +41,14 @@
 // limitations under the License.
 
 use crossbeam::queue::SegQueue;
-use futures::sync::oneshot;
-use futures::Future;
-use std::sync::{Arc, Mutex};
+use futures::channel::oneshot;
+use futures::lock::Mutex;
+use std::sync::Arc;
 
-use manage_connection::ManageConnection;
-use queue::{Live, Queue};
-use Config;
-use Error;
+use crate::manage_connection::ManageConnection;
+use crate::queue::{Live, Queue};
+use crate::Config;
+use crate::Error;
 
 /// Inner connection pool. Handles creating and holding the connections, as well as keeping track of
 /// futures that are waiting on connections.
@@ -79,8 +79,8 @@ impl<C: ManageConnection> ConnectionPool<C> {
         self.config.max_size
     }
 
-    pub fn connect(&self) -> Box<dyn Future<Item = C::Connection, Error = Error<C::Error>> + Send> {
-        self.manager.connect()
+    pub async fn connect(&self) -> Result<C::Connection, Error<C::Error>> {
+        self.manager.connect().await
     }
 
     /// Adds a "waiter" to the queue of waiting futures. When a new connection becomes available,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,7 +211,7 @@ impl<C: ManageConnection + Send> Pool<C> {
         this: &Self,
         conns: &Arc<queue::Queue<<C as ManageConnection>::Connection>>,
     ) -> Option<Result<Live<C::Connection>, Error<C::Error>>> {
-        if let Some(_) = conns.safe_increment(this.conn_pool.max_size()) {
+        if conns.safe_increment(this.conn_pool.max_size()).is_some() {
             let conns = Arc::clone(&conns);
             let result = match this.conn_pool.connect().await {
                 Ok(conn) => Ok(Live::new(conn)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,9 +214,7 @@ impl<C: ManageConnection + Send> Pool<C> {
         if let Some(_) = conns.safe_increment(this.conn_pool.max_size()) {
             let conns = Arc::clone(&conns);
             let result = match this.conn_pool.connect().await {
-                Ok(conn) => {
-                    Ok(Live::new(conn))
-                }
+                Ok(conn) => Ok(Live::new(conn)),
                 Err(err) => {
                     // if we weren't able to make a new connection, we need to decrement
                     // connections, since we preincremented the connection count for this  one

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -338,7 +338,7 @@ mod tests {
             Ok(())
         }
 
-        async fn is_valid(&self, _conn: Self::Connection) -> Result<(), Error<Self::Error>> {
+        async fn is_valid(&self, _conn: &mut Self::Connection) -> Result<(), Error<Self::Error>> {
             unimplemented!()
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ use tokio::time;
 
 use crate::error::InternalError;
 
-pub use conn::{Conn, ConnFuture};
+pub use conn::Conn;
 pub use manage_connection::ManageConnection;
 
 use inner::ConnectionPool;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@
 //!
 //! Any connection type that implements the `ManageConnection` trait can be used with this libary.
 
-extern crate crossbeam;
+extern crate crossbeam_queue;
 extern crate futures;
 extern crate tokio;
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,8 @@ extern crate tokio;
 extern crate failure;
 #[macro_use]
 extern crate log;
+#[macro_use]
+extern crate async_trait;
 
 mod conn;
 mod error;
@@ -57,14 +59,15 @@ mod inner;
 mod manage_connection;
 mod queue;
 
-use futures::future::{self, Either, Future};
+use futures::channel::oneshot;
+use futures::future::{self};
+use futures::prelude::*;
 use futures::stream;
-use futures::sync::oneshot;
-use futures::Stream;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
-use tokio::executor;
-use tokio::timer::Delay;
+use std::time::Duration;
+use tokio::time;
+
+use crate::error::InternalError;
 
 pub use conn::{Conn, ConnFuture};
 pub use manage_connection::ManageConnection;
@@ -122,33 +125,30 @@ impl<C: ManageConnection + Send> Pool<C> {
     ///
     /// The returned future will resolve to the pool if successful, which can then be used
     /// immediately.
-    pub fn new(
-        manager: C,
-        config: Config,
-    ) -> Box<dyn Future<Item = Pool<C>, Error = Error<C::Error>> + Send> {
+    pub async fn new(manager: C, config: Config) -> Result<Pool<C>, Error<C::Error>> {
         assert!(
             config.max_size >= config.min_size,
             "max_size of pool must be greater than or equal to the min_size"
         );
 
-        let conns = stream::futures_unordered(
-            ::std::iter::repeat(&manager)
-                .take(config.min_size)
-                .map(|c| c.connect()),
-        );
+        let conns: stream::FuturesUnordered<_> = std::iter::repeat(&manager)
+            .take(config.min_size)
+            .map(|c| c.connect())
+            .collect();
 
         // Fold the connections we are creating into a Queue object
-        let conns = conns.fold::<_, _, Result<_, _>>(Queue::new(), |conns, conn| {
-            conns.new_conn(Live::new(conn));
-            Ok(conns)
-        });
+        let conns = conns
+            .try_fold(Queue::new(), |conns, conn| {
+                conns.new_conn(Live::new(conn));
+
+                future::ok(conns)
+            })
+            .await?;
 
         // Set up the pool once the connections are established
-        Box::new(conns.and_then(move |conns| {
-            let conn_pool = Arc::new(ConnectionPool::new(conns, manager, config));
+        let conn_pool = Arc::new(ConnectionPool::new(conns, manager, config));
 
-            Ok(Pool { conn_pool })
-        }))
+        Ok(Pool { conn_pool })
     }
 
     /// Returns a future that resolves to a connection from the pool.
@@ -158,70 +158,74 @@ impl<C: ManageConnection + Send> Pool<C> {
     ///
     /// This **does not** implement any timeout functionality. Timeout functionality can be added
     /// by calling `.timeout` on the returned future.
-    pub fn connection(&self) -> ConnFuture<Conn<C>, Error<C::Error>> {
-        let conns = self
-            .conn_pool
-            .conns
-            .lock()
-            .expect("posioned connection mutex");
+    pub async fn connection(&self) -> Result<Conn<C>, Error<C::Error>> {
+        let conns = self.conn_pool.conns.lock().await;
 
         debug!("connection: acquired connection lock");
         if let Some(conn) = conns.get() {
             debug!("connection: connection already in pool and ready to go");
-            future::Either::A(future::ok(Conn {
+            return Ok(Conn {
                 conn: Some(conn),
-                pool: self.clone(),
-            }))
+                pool: Some(self.clone()),
+            });
         } else {
             debug!("connection: try spawn connection");
-            if let Some(conn_future) = Self::try_spawn_connection(&self, &conns) {
+            if let Some(conn) = Self::try_spawn_connection(&self, &conns).await {
+                let conn = conn?;
                 let this = self.clone();
                 debug!("connection: try spawn connection");
-                return future::Either::B(Box::new(conn_future.map(|conn| Conn {
-                    conn: Some(conn),
-                    pool: this,
-                })));
-            }
-            // Have the pool notify us of the connection
-            let (tx, rx) = oneshot::channel();
-            debug!("connection: pushing to notify of connection");
-            self.conn_pool.notify_of_connection(tx);
 
-            // Prepare the future which will wait for a free connection
-            let this = self.clone();
-            debug!("connection: waiting for connection");
-            future::Either::B(Box::new(
-                rx.map(|conn| {
-                    debug!("connection: got connection after waiting");
-                    Conn {
-                        conn: Some(conn),
-                        pool: this,
-                    }
-                })
-                .map_err(|_err| unimplemented!()),
-            ))
+                return Ok(Conn {
+                    conn: Some(conn),
+                    pool: Some(this),
+                });
+            }
         }
+
+        // Have the pool notify us of the connection
+        let (tx, rx) = oneshot::channel();
+        debug!("connection: pushing to notify of connection");
+        self.conn_pool.notify_of_connection(tx);
+
+        // Prepare the future which will wait for a free connection
+        let this = self.clone();
+        debug!("connection: waiting for connection");
+
+        let conn = rx.await.map_err(|_| {
+            Error::Internal(InternalError::Other(
+                "Connection channel was closed unexpectedly".into(),
+            ))
+        })?;
+
+        debug!("connection: got connection after waiting");
+        Ok(Conn {
+            conn: Some(conn),
+            pool: Some(this),
+        })
     }
+
     /// Attempt to spawn a new connection. If we're not already over the max number of connections,
     /// a future will be returned that resolves to the new connection.
     /// Otherwise, None will be returned
-    pub(crate) fn try_spawn_connection(
+    pub(crate) async fn try_spawn_connection(
         this: &Self,
         conns: &Arc<queue::Queue<<C as ManageConnection>::Connection>>,
-    ) -> Option<Box<dyn Future<Item = Live<C::Connection>, Error = Error<C::Error>> + Send>> {
+    ) -> Option<Result<Live<C::Connection>, Error<C::Error>>> {
         if let Some(_) = conns.safe_increment(this.conn_pool.max_size()) {
             let conns = Arc::clone(&conns);
-            Some(Box::new(this.conn_pool.connect().then(
-                move |result| match result {
-                    Ok(conn) => Ok(Live::new(conn)),
-                    Err(err) => {
-                        // if we weren't able to make a new connection, we need to decrement
-                        // connections, since we preincremented the connection count for this  one
-                        conns.decrement();
-                        Err(err)
-                    }
-                },
-            )))
+            let result = match this.conn_pool.connect().await {
+                Ok(conn) => {
+                    Ok(Live::new(conn))
+                }
+                Err(err) => {
+                    // if we weren't able to make a new connection, we need to decrement
+                    // connections, since we preincremented the connection count for this  one
+                    conns.decrement();
+                    Err(err)
+                }
+            };
+
+            Some(result)
         } else {
             None
         }
@@ -230,15 +234,11 @@ impl<C: ManageConnection + Send> Pool<C> {
     /// of two outcomes:
     /// * The connection will be passed to a waiting future, if any exist.
     /// * The connection will be put back into the connection pool.
-    pub fn put_back(&self, mut conn: Live<C::Connection>) {
+    pub async fn put_back(&self, mut conn: Live<C::Connection>) {
         debug!("put_back: start put back");
 
         let broken = self.conn_pool.has_broken(&mut conn);
-        let conns = self
-            .conn_pool
-            .conns
-            .lock()
-            .expect("posioned connection mutex");
+        let conns = self.conn_pool.conns.lock().await;
         debug!("put_back: got lock for put back");
 
         if broken {
@@ -269,62 +269,50 @@ impl<C: ManageConnection + Send> Pool<C> {
 
     fn spawn_new_future_loop(&self) {
         let this1 = self.clone();
-        executor::spawn(future::loop_fn((), move |_| {
-            let this = this1.clone();
-            this.conn_pool.connect().then(move |res| match res {
-                Ok(conn) => {
-                    // Call put_back instead of new_conn because we want to give the waiting futures
-                    // a chance to get the connection if there are any.
-                    // However, this means we have to call increment before calling put_back,
-                    // as put_back assumes that the connection already exists.
-                    // This could probably use some refactoring
-                    let conns = this
-                        .conn_pool
-                        .conns
-                        .lock()
-                        .expect("posioned connection mutex");
-                    debug!("creating new connection from spawn loop");
-                    conns.increment();
-                    // Drop so we free the lock
-                    ::std::mem::drop(conns);
+        tokio::spawn(async move {
+            loop {
+                let this = this1.clone();
 
-                    this.put_back(Live::new(conn));
+                let res = this.conn_pool.connect().await;
+                match res {
+                    Ok(conn) => {
+                        // Call put_back instead of new_conn because we want to give the waiting futures
+                        // a chance to get the connection if there are any.
+                        // However, this means we have to call increment before calling put_back,
+                        // as put_back assumes that the connection already exists.
+                        // This could probably use some refactoring
+                        let conns = this.conn_pool.conns.lock().await;
+                        debug!("creating new connection from spawn loop");
+                        conns.increment();
+                        // Drop so we free the lock
+                        ::std::mem::drop(conns);
 
-                    Either::A(future::ok(future::Loop::Break(())))
+                        this.put_back(Live::new(conn)).await;
+
+                        break;
+                    }
+                    Err(err) => {
+                        error!(
+                            "unable to establish new connection, trying again: {:?}",
+                            err
+                        );
+                        // TODO: make this use config
+                        time::delay_for(Duration::from_secs(1)).await;
+                    }
                 }
-                Err(err) => {
-                    error!(
-                        "unable to establish new connection, trying again: {:?}",
-                        err
-                    );
-                    // TODO: make this use config
-                    Either::B(
-                        Delay::new(Instant::now() + Duration::from_secs(1))
-                            .map(|_| future::Loop::Continue(()))
-                            .map_err(|_e| panic!("delay timer errored, shutdown required")),
-                    )
-                }
-            })
-        }));
+            }
+        });
     }
 
     /// The total number of connections in the pool.
-    pub fn total_conns(&self) -> usize {
-        let conns = self
-            .conn_pool
-            .conns
-            .lock()
-            .expect("posioned connection mutex");
+    pub async fn total_conns(&self) -> usize {
+        let conns = self.conn_pool.conns.lock().await;
         conns.total()
     }
 
     /// The number of idle connections in the pool.
-    pub fn idle_conns(&self) -> usize {
-        let conns = self
-            .conn_pool
-            .conns
-            .lock()
-            .expect("posioned connection mutex");
+    pub async fn idle_conns(&self) -> usize {
+        let conns = self.conn_pool.conns.lock().await;
         conns.idle()
     }
 }
@@ -333,27 +321,20 @@ impl<C: ManageConnection + Send> Pool<C> {
 mod tests {
     use super::*;
     use std::time::Duration;
-    use tokio::prelude::FutureExt;
-    use tokio::runtime::current_thread::Runtime;
 
     #[derive(Debug)]
     pub struct DummyManager {}
 
+    #[async_trait]
     impl ManageConnection for DummyManager {
         type Connection = ();
         type Error = ();
 
-        fn connect(
-            &self,
-        ) -> Box<Future<Item = Self::Connection, Error = Error<Self::Error>> + 'static + Send>
-        {
-            Box::new(future::ok(()))
+        async fn connect(&self) -> Result<Self::Connection, Error<Self::Error>> {
+            Ok(())
         }
 
-        fn is_valid(
-            &self,
-            _conn: Self::Connection,
-        ) -> Box<Future<Item = (), Error = Error<Self::Error>>> {
+        async fn is_valid(&self, _conn: Self::Connection) -> Result<(), Error<Self::Error>> {
             unimplemented!()
         }
 
@@ -367,33 +348,19 @@ mod tests {
         }
     }
 
-    #[test]
-    fn simple_pool_creation_and_connection() {
+    #[tokio::test]
+    async fn simple_pool_creation_and_connection() {
         let mngr = DummyManager {};
         let config: Config = Default::default();
 
-        let future = Pool::new(mngr, config).and_then(|pool| {
-            pool.connection().and_then(|conn| {
-                if let Some(Live {
-                    conn: (),
-                    live_since: _,
-                }) = conn.conn
-                {
-                    Ok(())
-                } else {
-                    panic!("connection is not correct type")
-                }
-            })
-        });
+        let pool = Pool::new(mngr, config).await.unwrap();
+        let conn = pool.connection().await.unwrap();
 
-        Runtime::new()
-            .expect("could not run")
-            .block_on(future)
-            .expect("could not run");
+        assert!(conn.conn.is_some(), "connection is not correct type");
     }
 
-    #[test]
-    fn it_returns_a_non_resolved_future_when_over_pool_limit() {
+    #[tokio::test]
+    async fn it_returns_a_non_resolved_future_when_over_pool_limit() {
         let mngr = DummyManager {};
         let config: Config = Config {
             max_size: 1,
@@ -401,31 +368,17 @@ mod tests {
         };
 
         // pool is of size , we try to get 2 connections so the second one will never resolve
-        let future = Pool::new(mngr, config).and_then(|pool| {
-            // Forget the values so we don't drop them, and return them back to the pool
-            ::std::mem::forget(pool.connection());
-            pool.connection()
-                .timeout(Duration::from_millis(10))
-                .then(|r| match r {
-                    Ok(_) => panic!("didn't timeout"),
-                    Err(err) => {
-                        if err.is_elapsed() {
-                            Ok(())
-                        } else {
-                            panic!("didn't timeout")
-                        }
-                    }
-                })
-        });
+        let pool = Pool::new(mngr, config).await.unwrap();
+        // Forget the values so we don't drop them, and return them back to the pool
+        ::std::mem::forget(pool.connection());
 
-        Runtime::new()
-            .expect("could not run")
-            .block_on(future)
-            .expect("could not run");
+        let result = tokio::time::timeout(Duration::from_millis(10), pool.connection()).await;
+
+        assert!(result.is_err(), "didn't timeout");
     }
 
-    #[test]
-    fn it_allocates_new_connections_up_to_max_size() {
+    #[tokio::test]
+    async fn it_allocates_new_connections_up_to_max_size() {
         let mngr = DummyManager {};
         let config: Config = Config {
             max_size: 2,
@@ -434,47 +387,25 @@ mod tests {
 
         // pool is of size 1, but is allowed to generate new connections up to 2.
         // When we try 2 connections, they should both pass without timing out
-        let future = Pool::new(mngr, config).and_then(|pool| {
-            // Forget the values so we don't drop them, and return them back to the pool
-            ::std::mem::forget(pool.connection());
-            let f1 = pool
-                .connection()
-                .timeout(Duration::from_millis(10))
-                .then(|r| match r {
-                    Ok(conn) => {
-                        ::std::mem::forget(conn);
-                        Ok(())
-                    }
-                    Err(err) => {
-                        if err.is_elapsed() {
-                            panic!("second connection timed out")
-                        } else {
-                            Ok(())
-                        }
-                    }
-                });
+        let pool = Pool::new(mngr, config).await.unwrap();
 
-            // The third connection should timeout though, as we're only allowed to go up to 2
-            let f2 = pool
-                .connection()
-                .timeout(Duration::from_millis(10))
-                .then(|r| match r {
-                    Ok(_) => panic!("third didn't timeout"),
-                    Err(err) => {
-                        if err.is_elapsed() {
-                            Ok(())
-                        } else {
-                            panic!("third didn't timeout")
-                        }
-                    }
-                });
+        // Forget the values so we don't drop them, and return them back to the pool
+        ::std::mem::forget(pool.connection());
 
-            f1.join(f2)
-        });
+        let f1 = async {
+            let conn = tokio::time::timeout(Duration::from_millis(10), pool.connection())
+                .await
+                .expect("second connection timed out");
+            ::std::mem::forget(conn);
+        };
 
-        Runtime::new()
-            .expect("could not run")
-            .block_on(future)
-            .expect("could not run");
+        // The third connection should timeout though, as we're only allowed to go up to 2
+        let f2 = async {
+            let result = tokio::time::timeout(Duration::from_millis(10), pool.connection()).await;
+
+            assert!(result.is_err(), "third didn't timeout");
+        };
+
+        futures::join!(f1, f2);
     }
 }

--- a/src/manage_connection.rs
+++ b/src/manage_connection.rs
@@ -43,7 +43,7 @@ pub trait ManageConnection: Send + Sync + 'static {
     ///
     /// Note that boxing is used here since impl Trait is not yet supported
     /// within trait definitions.
-    async fn is_valid(&self, conn: Self::Connection) -> Result<(), L337Error<Self::Error>>;
+    async fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), L337Error<Self::Error>>;
 
     /// Quick check to determine if the connection has broken
     fn has_broken(&self, conn: &mut Self::Connection) -> bool;

--- a/src/manage_connection.rs
+++ b/src/manage_connection.rs
@@ -21,11 +21,11 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-use futures::Future;
+use crate::Error as L337Error;
 use std::fmt::Debug;
-use Error as L337Error;
 
 /// A trait which provides connection-specific functionality.
+#[async_trait]
 pub trait ManageConnection: Send + Sync + 'static {
     /// The connection type this manager deals with.
     type Connection: Send + 'static;
@@ -37,18 +37,13 @@ pub trait ManageConnection: Send + Sync + 'static {
     ///
     /// Note that boxing is used here since impl Trait is not yet supported
     /// within trait definitions.
-    fn connect(
-        &self,
-    ) -> Box<dyn Future<Item = Self::Connection, Error = L337Error<Self::Error>> + 'static + Send>;
+    async fn connect(&self) -> Result<Self::Connection, L337Error<Self::Error>>;
 
     /// Determines if the connection is still connected to the database.
     ///
     /// Note that boxing is used here since impl Trait is not yet supported
     /// within trait definitions.
-    fn is_valid(
-        &self,
-        conn: Self::Connection,
-    ) -> Box<dyn Future<Item = (), Error = L337Error<Self::Error>>>;
+    async fn is_valid(&self, conn: Self::Connection) -> Result<(), L337Error<Self::Error>>;
 
     /// Quick check to determine if the connection has broken
     fn has_broken(&self, conn: &mut Self::Connection) -> bool;

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -57,7 +57,7 @@ pub struct Live<T: Send> {
 impl<T: Send> Live<T> {
     pub fn new(conn: T) -> Live<T> {
         Live {
-            conn: conn,
+            conn,
             live_since: Instant::now(),
         }
     }
@@ -73,7 +73,7 @@ struct Idle<T: Send> {
 impl<T: Send> Idle<T> {
     fn new(conn: Live<T>) -> Idle<T> {
         Idle {
-            conn: conn,
+            conn,
             idle_since: Instant::now(),
         }
     }

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -43,7 +43,7 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Instant;
 
-use crossbeam::queue::SegQueue;
+use crossbeam_queue::SegQueue;
 
 // Almost all of this file is directly from c3po: https://github.com/withoutboats/c3po/blob/08a6fde00c6506bacfe6eebe621520ee54b418bb/src/queue.rs
 
@@ -126,7 +126,7 @@ impl<C: Send> Queue<C> {
 
     /// Get the longest-idle connection from the queue.
     pub fn get(&self) -> Option<Live<C>> {
-        self.idle.try_pop().map(|Idle { conn, .. }| {
+        self.idle.pop().ok().map(|Idle { conn, .. }| {
             self.idle_count.fetch_sub(1, Ordering::SeqCst);
             conn
         })


### PR DESCRIPTION
Futures-0.3 and Tokio-0.2 will be the maintained versions of these libraries going forward, and they have many speed improvements over the old ones.

I can squash these commits down into one larger one, if that would be better.