### PR TITLE
Use failure::Fail as the error trait

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -3,3 +3,15 @@ pub enum InternalError {
     #[fail(display = "unknown error: {}", _0)]
     Other(String),
 }
+
+/// Error type returned by this module
+#[derive(Debug, Fail)]
+pub enum Error<E: failure::Fail> {
+    /// Error coming from the connection pooling itself
+    #[fail(display = "l337 internal error: {}", _0)]
+    Internal(InternalError),
+
+    /// Error from the connection manager or the underlying client
+    #[fail(display = "l337 manager error: {}", _0)]
+    External(E),
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,7 @@ use tokio::time;
 use crate::error::InternalError;
 
 pub use conn::Conn;
+pub use error::Error;
 pub use manage_connection::ManageConnection;
 
 use inner::ConnectionPool;
@@ -88,15 +89,6 @@ pub struct Config {
     pub min_size: usize,
     /// Max number of connections to keep in the pool
     pub max_size: usize,
-}
-
-/// Error type returned by this module
-#[derive(Debug)]
-pub enum Error<E: Send + 'static> {
-    /// Error coming from the connection pooling itself
-    Internal(error::InternalError),
-    /// Error from the connection manager or the underlying client
-    External(E),
 }
 
 impl Default for Config {
@@ -327,6 +319,10 @@ mod tests {
     #[derive(Debug)]
     pub struct DummyManager {}
 
+    #[derive(Debug, Fail)]
+    #[fail(display = "DummyError")]
+    pub struct DummyError;
+
     impl DummyManager {
         pub fn new() -> Self {
             Self {}
@@ -336,7 +332,7 @@ mod tests {
     #[async_trait]
     impl ManageConnection for DummyManager {
         type Connection = ();
-        type Error = ();
+        type Error = DummyError;
 
         async fn connect(&self) -> Result<Self::Connection, Error<Self::Error>> {
             Ok(())

--- a/src/manage_connection.rs
+++ b/src/manage_connection.rs
@@ -22,7 +22,6 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 use crate::Error as L337Error;
-use std::fmt::Debug;
 
 /// A trait which provides connection-specific functionality.
 #[async_trait]
@@ -31,7 +30,7 @@ pub trait ManageConnection: Send + Sync + 'static {
     type Connection: Send + 'static;
 
     /// The error type returned by `Connection`s.
-    type Error: Send + 'static + Debug;
+    type Error: failure::Fail;
 
     /// Attempts to create a new connection.
     ///


### PR DESCRIPTION
Currently, our error types do not implement std::error::Error or
failure::Fail. One of these error types should be implemented for our
error enums for maximum compatibility.