### PR TITLE
Add debug implementations for Pool & redis manager

### DIFF
--- a/src/inner.rs
+++ b/src/inner.rs
@@ -43,6 +43,7 @@
 use crossbeam_queue::SegQueue;
 use futures::channel::oneshot;
 use futures::lock::Mutex;
+use std::fmt;
 use std::sync::Arc;
 
 use crate::manage_connection::ManageConnection;
@@ -62,6 +63,16 @@ pub struct ConnectionPool<C: ManageConnection + Send> {
     manager: C,
     /// Configuration for the pool
     config: Config,
+}
+
+impl<C: ManageConnection + Send + fmt::Debug> fmt::Debug for ConnectionPool<C> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("ConnectionPool")
+            .field("waiting_count", &self.waiting.len())
+            .field("manager", &self.manager)
+            .field("config", &self.config)
+            .finish()
+    }
 }
 
 impl<C: ManageConnection> ConnectionPool<C> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,7 @@ use futures::channel::oneshot;
 use futures::future::{self};
 use futures::prelude::*;
 use futures::stream;
+use std::fmt;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::time;
@@ -79,6 +80,20 @@ use queue::{Live, Queue};
 /// General connection pool
 pub struct Pool<C: ManageConnection + Send> {
     conn_pool: Arc<ConnectionPool<C>>,
+}
+
+impl<C: ManageConnection + Send + fmt::Debug> fmt::Debug for Pool<C> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let (total, idle) = futures::executor::block_on(async {
+            futures::join!(self.total_conns(), self.idle_conns())
+        });
+
+        f.debug_struct("Pool")
+            .field("conn_pool", &self.conn_pool)
+            .field("total_conns", &total)
+            .field("idle_conns", &idle)
+            .finish()
+    }
 }
 
 /// Configuration for the connection pool

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,14 +84,8 @@ pub struct Pool<C: ManageConnection + Send> {
 
 impl<C: ManageConnection + Send + fmt::Debug> fmt::Debug for Pool<C> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let (total, idle) = futures::executor::block_on(async {
-            futures::join!(self.total_conns(), self.idle_conns())
-        });
-
         f.debug_struct("Pool")
             .field("conn_pool", &self.conn_pool)
-            .field("total_conns", &total)
-            .field("idle_conns", &idle)
             .finish()
     }
 }


### PR DESCRIPTION
It's annoying having to hand-write debug impls for types that previously
had derive(debug) when using r2d2 pools.