### PR TITLE
Rewrite redis async_transaction, remove some synchronization overhead

### DIFF
--- a/src/conn.rs
+++ b/src/conn.rs
@@ -98,9 +98,7 @@ where
         let conn = self.conn.take().unwrap();
         let pool = self.pool.take().unwrap();
 
-        tokio::spawn(async move {
-            pool.put_back(conn).await;
-        });
+        pool.put_back(conn);
     }
 }
 
@@ -121,10 +119,10 @@ mod tests {
         };
 
         let pool = Pool::new(mngr, config).await.unwrap();
-        assert_eq!(pool.idle_conns().await, 2);
+        assert_eq!(pool.idle_conns(), 2);
 
         let conn = pool.connection().await.unwrap();
-        assert_eq!(pool.idle_conns().await, 1);
+        assert_eq!(pool.idle_conns(), 1);
 
         ::std::mem::drop(conn);
 
@@ -132,6 +130,6 @@ mod tests {
         // to wait for the future to finish.
         delay_for(Duration::from_secs(1)).await;
 
-        assert_eq!(pool.idle_conns().await, 2);
+        assert_eq!(pool.idle_conns(), 2);
     }
 }

--- a/src/inner.rs
+++ b/src/inner.rs
@@ -42,7 +42,6 @@
 
 use crossbeam_queue::SegQueue;
 use futures::channel::oneshot;
-use futures::lock::Mutex;
 use std::fmt;
 use std::sync::Arc;
 
@@ -55,7 +54,7 @@ use crate::Error;
 /// futures that are waiting on connections.
 pub struct ConnectionPool<C: ManageConnection + Send> {
     /// Queue of connections in the pool
-    pub conns: Mutex<Arc<Queue<C::Connection>>>,
+    pub conns: Arc<Queue<C::Connection>>,
     /// Queue of oneshot's that are waiting to be given a new connection when the current pool is
     /// already saturated.
     waiting: SegQueue<oneshot::Sender<Live<C::Connection>>>,
@@ -79,7 +78,7 @@ impl<C: ManageConnection> ConnectionPool<C> {
     /// Creates a new connection pool
     pub fn new(conns: Queue<C::Connection>, manager: C, config: Config) -> ConnectionPool<C> {
         ConnectionPool {
-            conns: Mutex::new(Arc::new(conns)),
+            conns: Arc::new(conns),
             waiting: SegQueue::new(),
             manager,
             config,


### PR DESCRIPTION
I know the back-and-forth on async_transaction isn't doing us any favors, but it was very difficult to work with the macro version, and having a function here allows us to more easily understand what is happening. It does introduce the args parameter, which is a bit cumbersome to use, but there is really no other way to properly pass values into a closure which returns a future, at least until proper async closures are stabilized.

I believe that the mutex used to guard the connection pool was not necessary, since all of the values within it were atomic and Send/Sync already. I also removed the separate idle_count variable on the connection pool, as this was just a proxy for the length of the idle connections queue.