### PR TITLE
Prepare for 0.3.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "l337"
-version = "0.0.0"
+version = "0.3.0"
 authors = ["Jonathon Sheffield <samsmug@gmail.com>", "Joe Wilm <joe@jwilm.com>"]
 license = "MIT OR Apache-2.0"
 description = "yet another connection pooler"

--- a/l337-postgres/Cargo.toml
+++ b/l337-postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "l337-postgres"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Jonathon Sheffield <samsmug@gmail.com>"]
 edition = "2018"
 

--- a/l337-redis/Cargo.toml
+++ b/l337-redis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "l337-redis"
-version = "0.1.0"
+version = "0.3.0"
 authors = ["Jonathon Sheffield <samsmug@gmail.com>"]
 edition = "2018"
 


### PR DESCRIPTION
Version 0.3.0 was selected because the latest version that any of the
crates currently had was 0.2.0. Making all packages 0.3.0 ensures that
we have consistent version numbers across all of the packages.