### PR TITLE
Ignore channel send error when redis conn dies

### DIFF
--- a/l337-redis/Cargo.toml
+++ b/l337-redis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "l337-redis"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Jonathon Sheffield <samsmug@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/l337-redis/src/lib.rs
+++ b/l337-redis/src/lib.rs
@@ -173,12 +173,10 @@ impl l337::ManageConnection for RedisConnectionManager {
             future.await;
             debug!("Future backing redis connection ended, future calls to this redis connection will fail");
 
-            if let Err(e) = tx.send(()) {
-                error!(
-                    "Failed to alert redis client that connection has ended: {:?}",
-                    e
-                );
-            }
+            // If there was an error sending this message, it means that the
+            // RedisConnectionManager has died, and there is no need to notify
+            // it that this connection has died.
+            let _ = tx.send(());
         });
 
         debug!("connect: redis connection established");


### PR DESCRIPTION
If there was an error sending this message, it means that the
RedisConnectionManager has died, and there is no need to notify
it that the connection has died.

I will publish v0.3.1 when this is merged.