### PR TITLE
Log long connection times

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "l337"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Jonathon Sheffield <samsmug@gmail.com>", "Joe Wilm <joe@jwilm.com>"]
 license = "MIT OR Apache-2.0"
 description = "yet another connection pooler"
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 futures = "0.3"
-tokio = { version = "0.2", features = ["rt-core", "time"] }
+tokio = { version = "0.2.11", features = ["rt-core", "time", "macros"] }
 crossbeam-queue = "0.2"
 failure = "0.1.2"
 log = "0.4"
@@ -19,6 +19,3 @@ members = [
   "l337-postgres",
   "l337-redis"
 ]
-
-[dev-dependencies]
-tokio = { version = "0.2", features = ["macros", "rt-core", "time"] }

--- a/src/wait.rs
+++ b/src/wait.rs
@@ -1,0 +1,53 @@
+use std::time::{Duration, Instant};
+
+use futures::future::Future;
+
+/// Run a future, and call the provided function at the specified intervals until the future completes
+pub(crate) async fn run_future_with_interval<F, O>(
+    mut funk: impl FnMut(Duration),
+    duration: Duration,
+    future: F,
+) -> O
+where
+    F: Future<Output = O>,
+{
+    let start = Instant::now();
+    futures::pin_mut!(future);
+
+    loop {
+        tokio::select! {
+            result = &mut future => {
+                return result;
+            }
+            _ = tokio::time::delay_for(duration) => {
+                funk(start.elapsed());
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_works_correctly() {
+        let mut count = 0;
+
+        let return_value = run_future_with_interval(
+            |_| {
+                count += 1;
+            },
+            Duration::from_millis(250),
+            async {
+                tokio::time::delay_for(Duration::from_millis(1050)).await ;
+
+                24
+            },
+        )
+        .await;
+
+        assert_eq!(return_value, 24);
+        assert_eq!(count, 4);
+    }
+}


### PR DESCRIPTION
If a connection spends more than 5s waiting to be spawned, the time
will now be logged so that you can clearly see that there is a
connection waiting.