### PR TITLE
Check is_valid when pulling from pool

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "l337"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Jonathon Sheffield <samsmug@gmail.com>", "Joe Wilm <joe@jwilm.com>"]
 license = "MIT OR Apache-2.0"
 description = "yet another connection pooler"

--- a/l337-postgres/Cargo.toml
+++ b/l337-postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "l337-postgres"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Jonathon Sheffield <samsmug@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/l337-postgres/src/lib.rs
+++ b/l337-postgres/src/lib.rs
@@ -32,6 +32,9 @@ pub struct AsyncConnection {
     drop_tx: Option<oneshot::Sender<()>>,
 }
 
+// Connections can be dropped when they report an error from is_valid, or return
+// true from has_broken. The channel is used here to ensure that the async
+// driver task spawned in PostgresConnectionManager::connect is ended.
 impl Drop for AsyncConnection {
     fn drop(&mut self) {
         // If the receiver is gone here, it means the task is already finished,

--- a/l337-postgres/src/lib.rs
+++ b/l337-postgres/src/lib.rs
@@ -11,7 +11,7 @@ extern crate log;
 #[macro_use]
 extern crate async_trait;
 
-use futures::channel::oneshot;
+use futures::{channel::oneshot, prelude::*};
 use std::{
     convert::{AsMut, AsRef},
     ops::{Deref, DerefMut},
@@ -28,7 +28,18 @@ use std::fmt;
 pub struct AsyncConnection {
     pub client: Client,
     broken: bool,
-    receiver: oneshot::Receiver<bool>,
+    done_rx: oneshot::Receiver<()>,
+    drop_tx: Option<oneshot::Sender<()>>,
+}
+
+impl Drop for AsyncConnection {
+    fn drop(&mut self) {
+        // If the receiver is gone here, it means the task is already finished,
+        // and it's no problem.
+        if let Some(drop_tx) = self.drop_tx.take() {
+            let _ = drop_tx.send(());
+        }
+    }
 }
 
 impl Deref for AsyncConnection {
@@ -98,14 +109,27 @@ where
             .await
             .map_err(|e| l337::Error::External(e))?;
 
-        let (sender, receiver) = oneshot::channel();
+        let (done_tx, done_rx) = oneshot::channel();
+        let (drop_tx, drop_rx) = oneshot::channel();
         spawn(async move {
             debug!("connect: start connection future");
-            if let Err(_) = connection.await {
-                sender
-                    .send(true)
-                    .unwrap_or_else(|e| panic!("failed to send shutdown notice: {}", e));
+            let connection = connection.fuse();
+            let drop_rx = drop_rx.fuse();
+
+            futures::pin_mut!(connection, drop_rx);
+
+            futures::select! {
+                result = connection => {
+                    if let Err(e) = result {
+                        warn!("future backing postgres future ended with an error: {}", e);
+                    }
+                }
+                _ = drop_rx => { }
             }
+
+            // If this fails to send, the connection object was already dropped and does not need to be notified
+            let _ = done_tx.send(());
+
             info!("connect: connection future ended");
         });
 
@@ -113,7 +137,8 @@ where
         Ok(AsyncConnection {
             broken: false,
             client,
-            receiver,
+            done_rx,
+            drop_tx: Some(drop_tx),
         })
     }
 
@@ -134,7 +159,7 @@ where
         // Use try_recv() as `has_broken` can be called via Drop and not have a
         // future Context to poll on.
         // https://docs.rs/futures/0.3.1/futures/channel/oneshot/struct.Receiver.html#method.try_recv
-        match conn.receiver.try_recv() {
+        match conn.done_rx.try_recv() {
             // If we get any message, the connection task stopped, which means this connection is
             // now dead
             Ok(Some(_)) => {

--- a/l337-redis/Cargo.toml
+++ b/l337-redis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "l337-redis"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Jonathon Sheffield <samsmug@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/l337-redis/src/lib.rs
+++ b/l337-redis/src/lib.rs
@@ -46,6 +46,9 @@ pub struct AsyncConnection {
     broken: bool,
 }
 
+// Connections can be dropped when they report an error from is_valid, or return
+// true from has_broken. The channel is used here to ensure that the async
+// driver task spawned in RedisConnectionManager::connect is ended.
 impl Drop for AsyncConnection {
     fn drop(&mut self) {
         if let Some(drop_tx) = self.drop_tx.take() {

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,9 @@
 pub enum InternalError {
     #[fail(display = "unknown error: {}", _0)]
     Other(String),
+
+    #[fail(display = "Tried to get a connection from the pool, but all connections were invalid")]
+    AllConnectionsInvalid,
 }
 
 /// Error type returned by this module

--- a/src/inner.rs
+++ b/src/inner.rs
@@ -105,6 +105,10 @@ impl<C: ManageConnection> ConnectionPool<C> {
         self.waiting.pop().ok()
     }
 
+    pub async fn is_valid(&self, conn: &mut C::Connection) -> Result<(), Error<C::Error>> {
+        self.manager.is_valid(conn).await
+    }
+
     pub fn has_broken(&self, conn: &mut Live<C::Connection>) -> bool {
         self.manager.has_broken(&mut conn.conn)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -496,7 +496,7 @@ mod tests {
     async fn it_does_not_return_connections_that_are_invalid() {
         let mngr = DummyManager::new();
         let config: Config = Config {
-            max_size: 1,
+            max_size: 2,
             min_size: 1,
         };
 
@@ -536,7 +536,7 @@ mod tests {
     async fn it_does_not_return_connections_that_are_broken() {
         let mngr = DummyManager::new();
         let config: Config = Config {
-            max_size: 1,
+            max_size: 2,
             min_size: 1,
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,7 @@ impl<C: ManageConnection + Send> Pool<C> {
     /// This **does not** implement any timeout functionality. Timeout functionality can be added
     /// by calling `.timeout` on the returned future.
     pub async fn connection(&self) -> Result<Conn<C>, Error<C::Error>> {
-        loop {
+        for _ in 0..self.conn_pool.max_size() {
             let mut connection = self.connection_inner().await?;
 
             match self.conn_pool.is_valid(&mut connection).await {
@@ -190,6 +190,8 @@ impl<C: ManageConnection + Send> Pool<C> {
                 }
             }
         }
+
+        Err(Error::Internal(InternalError::AllConnectionsInvalid))
     }
 
     async fn connection_inner(&self) -> Result<Conn<C>, Error<C::Error>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,13 +162,41 @@ impl<C: ManageConnection + Send> Pool<C> {
     /// This **does not** implement any timeout functionality. Timeout functionality can be added
     /// by calling `.timeout` on the returned future.
     pub async fn connection(&self) -> Result<Conn<C>, Error<C::Error>> {
+        loop {
+            let mut connection = self.connection_inner().await?;
+
+            match self.conn_pool.is_valid(&mut connection).await {
+                Ok(()) => return Ok(connection),
+                Err(e) => {
+                    debug!(
+                        "connection: found connection in pool that is no longer valid - removing from pool: {:?}",
+                        e
+                    );
+
+                    connection.forget();
+
+                    self.conn_pool.conns.decrement();
+                    debug!(
+                        "connection count is now: {:?}",
+                        self.conn_pool.conns.total()
+                    );
+                    self.spawn_new_future_loop();
+
+                    // In my experience, unconstrained loops in async fns are
+                    // problematic because tokio's scheduler will allow the task
+                    // to block up the runtime, so it is useful to add some
+                    // delays to loops to allow other futures to be polled.
+                    tokio::time::delay_for(Duration::from_millis(100)).await;
+                }
+            }
+        }
+    }
+
+    async fn connection_inner(&self) -> Result<Conn<C>, Error<C::Error>> {
         {
             if let Some(conn) = self.conn_pool.conns.get() {
                 debug!("connection: connection already in pool and ready to go");
-                return Ok(Conn {
-                    conn: Some(conn),
-                    pool: Some(self.clone()),
-                });
+                return Ok(Conn::new(conn, self.clone()));
             } else {
                 debug!("connection: try spawn connection");
                 if let Some(conn) = run_future_with_interval(
@@ -188,10 +216,10 @@ impl<C: ManageConnection + Send> Pool<C> {
                     let this = self.clone();
                     debug!("connection: spawned connection");
 
-                    return Ok(Conn {
-                        conn: Some(conn),
-                        pool: Some(this),
-                    });
+                    return Ok(Conn::new(
+                        conn,
+                        this,
+                    ));
                 }
             }
         }
@@ -224,10 +252,7 @@ impl<C: ManageConnection + Send> Pool<C> {
         })?;
 
         debug!("connection: got connection after waiting");
-        Ok(Conn {
-            conn: Some(conn),
-            pool: Some(this),
-        })
+        Ok(Conn::new(conn, this))
     }
 
     /// Attempt to spawn a new connection. If we're not already over the max number of connections,
@@ -348,7 +373,16 @@ mod tests {
     use tokio::time::timeout;
 
     #[derive(Debug)]
-    pub struct DummyManager {}
+    pub struct DummyManager {
+        last_id: AtomicUsize,
+    }
+
+    #[derive(Debug)]
+    pub struct DummyValue {
+        id: usize,
+        valid: Arc<AtomicBool>,
+        broken: bool,
+    }
 
     #[derive(Debug, Fail)]
     #[fail(display = "DummyError")]
@@ -356,25 +390,35 @@ mod tests {
 
     impl DummyManager {
         pub fn new() -> Self {
-            Self {}
+            Self {
+                last_id: AtomicUsize::new(0),
+            }
         }
     }
 
     #[async_trait]
     impl ManageConnection for DummyManager {
-        type Connection = ();
+        type Connection = DummyValue;
         type Error = DummyError;
 
         async fn connect(&self) -> Result<Self::Connection, Error<Self::Error>> {
-            Ok(())
+            Ok(DummyValue {
+                id: self.last_id.fetch_add(1, Ordering::SeqCst),
+                valid: Arc::new(AtomicBool::new(true)),
+                broken: false,
+            })
         }
 
-        async fn is_valid(&self, _conn: &mut Self::Connection) -> Result<(), Error<Self::Error>> {
-            unimplemented!()
+        async fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Error<Self::Error>> {
+            if conn.valid.load(Ordering::SeqCst) {
+                Ok(())
+            } else {
+                Err(Error::External(DummyError))
+            }
         }
 
-        fn has_broken(&self, _conn: &mut Self::Connection) -> bool {
-            false
+        fn has_broken(&self, conn: &mut Self::Connection) -> bool {
+            conn.broken
         }
 
         /// Produce an error representing a connection timeout.
@@ -444,6 +488,85 @@ mod tests {
         };
 
         futures::join!(f1, f2);
+    }
+
+    #[tokio::test]
+    async fn it_does_not_return_connections_that_are_invalid() {
+        let mngr = DummyManager::new();
+        let config: Config = Config {
+            max_size: 1,
+            min_size: 1,
+        };
+
+        let pool = Pool::new(mngr, config).await.unwrap();
+
+        let conn1 = pool.connection().await.unwrap();
+
+        let conn1_id = conn1.id;
+        let conn1_valid = Arc::clone(&conn1.valid);
+
+        // return conn1 to the connection pool
+        drop(conn1);
+
+        let conn1 = pool.connection().await.unwrap();
+
+        // The connection is still valid, so this should be the same as the
+        // original connection.
+        assert_eq!(conn1.id, conn1_id);
+
+        // return conn1 to the pool
+        drop(conn1);
+
+        // mark the connection as invalid
+        conn1_valid.store(false, Ordering::SeqCst);
+
+        // we should notice that the connection is invalid and create a new one
+        // before returning it
+        let conn2 = pool.connection().await.unwrap();
+
+        assert_ne!(
+            conn2.id, conn1_id,
+            "Conn1 was returned from the pool even though it is marked as invalid"
+        );
+    }
+
+    #[tokio::test]
+    async fn it_does_not_return_connections_that_are_broken() {
+        let mngr = DummyManager::new();
+        let config: Config = Config {
+            max_size: 1,
+            min_size: 1,
+        };
+
+        let pool = Pool::new(mngr, config).await.unwrap();
+
+        let conn1 = pool.connection().await.unwrap();
+
+        let conn1_id = conn1.id;
+
+        // return conn1 to the connection pool
+        drop(conn1);
+
+        let mut conn1 = pool.connection().await.unwrap();
+
+        // The connection is still valid, so this should be the same as the
+        // original connection.
+        assert_eq!(conn1.id, conn1_id);
+
+        // mark conn1 as broken, it should not be returned to the pool.
+        conn1.broken = true;
+
+        // try to return conn1 to the pool - should not be returned because it
+        // is marked as broken, and a new connection should be spawned in the
+        // background.
+        drop(conn1);
+
+        let conn2 = pool.connection().await.unwrap();
+
+        assert_ne!(
+            conn2.id, conn1_id,
+            "Conn1 was returned from the pool even though it is marked as broken"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
The is_valid method should be used when pulling a connection from the
pool to ensure that we do not hand an invalid connection to the caller.
If an invalid connection is pulled off the pool, it will be removed and
a new connection will be spawned onto the pool in its place.

I also added more channels to synchronize the status of the connection
wrappers with the async driver tasks.