### PR TITLE
breaking: Allow test-on-checkout to be optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "l337"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["Jonathon Sheffield <samsmug@gmail.com>", "Joe Wilm <joe@jwilm.com>"]
 license = "MIT OR Apache-2.0"
 description = "yet another connection pooler"

--- a/l337-postgres/Cargo.toml
+++ b/l337-postgres/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "l337-postgres"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Jonathon Sheffield <samsmug@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "l337 manager for tokio-postgres"
 
 [dependencies]
-l337 = { version = "0.3", path = ".." }
+l337 = { version = "0.4", path = ".." }
 futures = "0.3"
 tokio = "0.2"
 tokio-postgres = "0.5.1"

--- a/l337-redis/Cargo.toml
+++ b/l337-redis/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "l337-redis"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["Jonathon Sheffield <samsmug@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "l337 manager for redis"
 
 [dependencies]
-l337 = { version = "0.3", path = ".." }
+l337 = { version = "0.4", path = ".." }
 futures = "0.3"
 tokio = "0.2"
 redis = "0.14.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,46 @@
+/// Configuration for the connection pool
+#[derive(Debug)]
+pub struct Config {
+    pub(crate) min_size: usize,
+    pub(crate) max_size: usize,
+    pub(crate) test_on_check_out: bool,
+}
+
+impl Config {
+    /// Create a new configuration object with default values
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// If true, the health of a connection will be verified via a call to
+    /// `ConnectionManager::is_valid` before it is checked out of the pool.
+    ///
+    /// Defaults to true.
+    pub fn test_on_check_out(mut self, test_on_check_out: bool) -> Self {
+        self.test_on_check_out = test_on_check_out;
+        self
+    }
+
+    /// Minimum number of connections in the pool. The pool will be initialied with this number of
+    /// connections
+    pub fn min_size(mut self, min_size: usize) -> Self {
+        self.min_size = min_size;
+        self
+    }
+
+    /// Max number of connections to keep in the pool
+    pub fn max_size(mut self, max_size: usize) -> Self {
+        self.max_size = max_size;
+        self
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            max_size: 10,
+            min_size: 1,
+            test_on_check_out: true,
+        }
+    }
+}

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -140,10 +140,7 @@ mod tests {
     #[tokio::test]
     async fn conn_pushes_back_into_pool_after_drop() {
         let mngr = DummyManager::new();
-        let config = Config {
-            min_size: 2,
-            max_size: 2,
-        };
+        let config = Config::new().min_size(2).max_size(2);
 
         let pool = Pool::new(mngr, config).await.unwrap();
         assert_eq!(pool.idle_conns(), 2);

--- a/src/inner.rs
+++ b/src/inner.rs
@@ -61,7 +61,7 @@ pub struct ConnectionPool<C: ManageConnection + Send> {
     /// Connection manager used to create new connections as needed
     manager: C,
     /// Configuration for the pool
-    config: Config,
+    config: Arc<Config>,
 }
 
 impl<C: ManageConnection + Send + fmt::Debug> fmt::Debug for ConnectionPool<C> {
@@ -76,7 +76,7 @@ impl<C: ManageConnection + Send + fmt::Debug> fmt::Debug for ConnectionPool<C> {
 
 impl<C: ManageConnection> ConnectionPool<C> {
     /// Creates a new connection pool
-    pub fn new(conns: Queue<C::Connection>, manager: C, config: Config) -> ConnectionPool<C> {
+    pub fn new(conns: Queue<C::Connection>, manager: C, config: Arc<Config>) -> ConnectionPool<C> {
         ConnectionPool {
             conns: Arc::new(conns),
             waiting: SegQueue::new(),


### PR DESCRIPTION
This is a breaking change because our previous config object (struct
with all public fields) does not allow for config options to be added
without making a breaking change. Since a break was required anyways,
I felt it prudent to change the config in such a way that will allow us
to add options to the config in the future without a breaking change.