### PR TITLE
Add is_closed check to has_broken

### DIFF
--- a/l337-postgres/Cargo.toml
+++ b/l337-postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "l337-postgres"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Jonathon Sheffield <samsmug@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/l337-postgres/src/lib.rs
+++ b/l337-postgres/src/lib.rs
@@ -159,6 +159,10 @@ where
             return true;
         }
 
+        if conn.client.is_closed() {
+            return true;
+        }
+
         // Use try_recv() as `has_broken` can be called via Drop and not have a
         // future Context to poll on.
         // https://docs.rs/futures/0.3.1/futures/channel/oneshot/struct.Receiver.html#method.try_recv


### PR DESCRIPTION
This is used when the pool tries to put a connection back in, to verify
that the connection is still valid.