### PR TITLE
Add the ability to configure connection timeouts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "l337"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Jonathon Sheffield <samsmug@gmail.com>", "Joe Wilm <joe@jwilm.com>"]
 license = "MIT OR Apache-2.0"
 description = "yet another connection pooler"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,15 +1,28 @@
+use std::time::Duration;
+
 /// Configuration for the connection pool
 #[derive(Debug)]
 pub struct Config {
     pub(crate) min_size: usize,
     pub(crate) max_size: usize,
     pub(crate) test_on_check_out: bool,
+    pub(crate) connect_timeout: Option<Duration>,
 }
 
 impl Config {
     /// Create a new configuration object with default values
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Set timeout period for starting up a new connection. If it takes longer
+    /// than the specified time to wait for a connection to become available, it
+    /// will fail.
+    ///
+    /// By default, there is no timeout limit on getting a new connection.
+    pub fn connection_timeout(mut self, timeout: Duration) -> Self {
+        self.connect_timeout = Some(timeout);
+        self
     }
 
     /// If true, the health of a connection will be verified via a call to
@@ -23,12 +36,16 @@ impl Config {
 
     /// Minimum number of connections in the pool. The pool will be initialied with this number of
     /// connections
+    ///
+    /// Defaults to 1 connection.
     pub fn min_size(mut self, min_size: usize) -> Self {
         self.min_size = min_size;
         self
     }
 
     /// Max number of connections to keep in the pool
+    ///
+    /// Defaults to 10 connections.
     pub fn max_size(mut self, max_size: usize) -> Self {
         self.max_size = max_size;
         self
@@ -41,6 +58,7 @@ impl Default for Config {
             max_size: 10,
             min_size: 1,
             test_on_check_out: true,
+            connect_timeout: None,
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,6 +5,9 @@ pub enum InternalError {
 
     #[fail(display = "Tried to get a connection from the pool, but all connections were invalid")]
     AllConnectionsInvalid,
+
+    #[fail(display = "Timed out waiting for a connection to become available")]
+    TimedOut,
 }
 
 /// Error type returned by this module
@@ -17,4 +20,13 @@ pub enum Error<E: failure::Fail> {
     /// Error from the connection manager or the underlying client
     #[fail(display = "l337 manager error: {}", _0)]
     External(E),
+}
+
+impl<E> From<tokio::time::Elapsed> for Error<E>
+where
+    E: failure::Fail,
+{
+    fn from(_: tokio::time::Elapsed) -> Self {
+        Self::Internal(InternalError::TimedOut)
+    }
 }


### PR DESCRIPTION
Previously, we did not directly support connection timeouts, relying on
the end-user to call timeout on the returned future. It will be easier
for users to configure a default timeout that will be used for all
connection attempts. The default behavior is unchanged, if you do not
configure a timeout, there will be no timeout.