### PR TITLE
0.4.4: Add new API to expose the number of waiters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "l337"
-version = "0.4.3"
+version = "0.4.4"
 authors = ["Jonathon Sheffield <samsmug@gmail.com>",
            "Joe Wilm <joe@jwilm.com>",
            "keith Noguchi <keith@onesignal.com>"]

--- a/src/inner.rs
+++ b/src/inner.rs
@@ -54,10 +54,10 @@ use crate::Error;
 /// futures that are waiting on connections.
 pub struct ConnectionPool<C: ManageConnection + Send> {
     /// Queue of connections in the pool
-    pub conns: Arc<Queue<C::Connection>>,
+    pub(crate) conns: Arc<Queue<C::Connection>>,
     /// Queue of oneshot's that are waiting to be given a new connection when the current pool is
     /// already saturated.
-    waiting: SegQueue<oneshot::Sender<Live<C::Connection>>>,
+    pub(crate) waiting: SegQueue<oneshot::Sender<Live<C::Connection>>>,
     /// Connection manager used to create new connections as needed
     manager: C,
     /// Configuration for the pool

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -347,6 +347,11 @@ impl<C: ManageConnection + Send> Pool<C> {
     pub fn idle_conns(&self) -> usize {
         self.conn_pool.conns.idle()
     }
+
+    /// The number of waiters for the next available connections.
+    pub fn waiters(&self) -> usize {
+        self.conn_pool.waiting.len()
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This will expose the number of futures waiting for the new connection
when the pool hits the maximum number of active connections.