### PR TITLE
0.4.5: Make broken connection handling configurable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "l337"
-version = "0.4.4"
+version = "0.4.5"
 authors = ["Jonathon Sheffield <samsmug@gmail.com>",
            "Joe Wilm <joe@jwilm.com>",
            "keith Noguchi <keith@onesignal.com>"]

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,6 +6,7 @@ pub struct Config {
     pub(crate) min_size: usize,
     pub(crate) max_size: usize,
     pub(crate) test_on_check_out: bool,
+    pub(crate) recreate_broken_connections: bool,
     pub(crate) connect_timeout: Option<Duration>,
 }
 
@@ -34,6 +35,15 @@ impl Config {
         self
     }
 
+    /// If true, the new connection will be created when the broken connection
+    /// is put back to the pool.  Or, it will be just dropped.
+    ///
+    /// Default to true.
+    pub fn recreate_broken_connections(mut self, recreate: bool) -> Self {
+        self.recreate_broken_connections = recreate;
+        self
+    }
+
     /// Minimum number of connections in the pool. The pool will be initialied with this number of
     /// connections
     ///
@@ -58,6 +68,7 @@ impl Default for Config {
             max_size: 10,
             min_size: 1,
             test_on_check_out: true,
+            recreate_broken_connections: true,
             connect_timeout: None,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -281,7 +281,9 @@ impl<C: ManageConnection + Send> Pool<C> {
                 "connection count is now: {:?}",
                 self.conn_pool.conns.total()
             );
-            self.spawn_new_future_loop();
+            if self.config.recreate_broken_connections {
+                self.spawn_new_future_loop();
+            }
             return;
         }
 


### PR DESCRIPTION
It will re-create a new connection by default.  You can disable
this feature through the new config API, recreate_broken_connections().