### PR TITLE
queue: Use crossbeam_queue::ArrayQueue for idle connections pool

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "l337"
-version = "0.4.4"
+version = "0.4.5"
 authors = ["Jonathon Sheffield <samsmug@gmail.com>",
            "Joe Wilm <joe@jwilm.com>",
            "keith Noguchi <keith@onesignal.com>"]

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 pub struct Config {
     pub(crate) min_size: usize,
     pub(crate) max_size: usize,
+    pub(crate) idle_queue_size: usize,
     pub(crate) test_on_check_out: bool,
     pub(crate) connect_timeout: Option<Duration>,
 }
@@ -48,15 +49,27 @@ impl Config {
     /// Defaults to 10 connections.
     pub fn max_size(mut self, max_size: usize) -> Self {
         self.max_size = max_size;
+        self.idle_queue_size = max_size * IDLE_QUEUE_SIZE_FACTOR;
         self
     }
 }
 
+/// Initial minimum connection count(s) in the pool.
+const MIN_SIZE: usize = 1;
+/// Maximum connections, both active and idle, in the pool.
+const MAX_SIZE: usize = 10;
+/// Idle connection queue size factor applied to the MAX_SIZE above for the idle
+/// connection queue.  This technically should be 1, to make the idle queue size
+/// equal to the maximum number of connection in the pool, as we won't allow the
+/// total number of connections, both live and idel, exceed to maximum size.
+const IDLE_QUEUE_SIZE_FACTOR: usize = 2;
+
 impl Default for Config {
     fn default() -> Self {
         Config {
-            max_size: 10,
-            min_size: 1,
+            max_size: MAX_SIZE,
+            min_size: MIN_SIZE,
+            idle_queue_size: MAX_SIZE * IDLE_QUEUE_SIZE_FACTOR,
             test_on_check_out: true,
             connect_timeout: None,
         }

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -43,7 +43,7 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Instant;
 
-use crossbeam_queue::SegQueue;
+use crossbeam_queue::{ArrayQueue, PushError};
 
 // Almost all of this file is directly from c3po: https://github.com/withoutboats/c3po/blob/08a6fde00c6506bacfe6eebe621520ee54b418bb/src/queue.rs
 
@@ -65,7 +65,7 @@ impl<T: Send> Live<T> {
 
 /// An idle connection, carrying with it a record of how long it has been idle.
 #[derive(Debug)]
-struct Idle<T: Send> {
+pub(crate) struct Idle<T: Send> {
     conn: Live<T>,
     idle_since: Instant,
 }
@@ -83,59 +83,71 @@ impl<T: Send> Idle<T> {
 /// (including those which are not in the queue.)
 #[derive(Debug)]
 pub struct Queue<C: Send> {
-    idle: SegQueue<Idle<C>>,
+    idle: ArrayQueue<Idle<C>>,
     total_count: AtomicUsize,
+    idle_push_error_count: AtomicUsize,
 }
 
 impl<C: Send> Queue<C> {
     /// Construct an empty queue with a certain capacity
-    pub fn new() -> Queue<C> {
+    pub(crate) fn new(capacity: usize) -> Queue<C> {
         Queue {
-            idle: SegQueue::new(),
+            idle: ArrayQueue::new(capacity),
             total_count: AtomicUsize::new(0),
+            idle_push_error_count: AtomicUsize::new(0),
         }
     }
 
     /// Count of idle connection in queue
     #[inline(always)]
-    pub fn idle(&self) -> usize {
+    pub(crate) fn idle(&self) -> usize {
         self.idle.len()
     }
 
     /// Count of total connections active
     #[inline(always)]
-    pub fn total(&self) -> usize {
+    pub(crate) fn total(&self) -> usize {
         self.total_count.load(Ordering::SeqCst)
+    }
+
+    /// Error counter incremented in `store()` method above.
+    pub(crate) fn idle_push_error_count(&self) -> usize {
+        self.idle_push_error_count.load(Ordering::Relaxed)
     }
 
     /// Push a new connection into the queue (this will increment
     /// the total connection count).
-    pub fn new_conn(&self, conn: Live<C>) {
-        self.store(conn);
-        self.increment();
+    pub(crate) fn new_conn(&self, conn: Live<C>) {
+        if self.store(conn).is_ok() {
+            self.increment();
+        }
     }
 
     /// Store a connection which has already been counted in the queue
     /// (this will NOT increment the total connection count).
-    pub fn store(&self, conn: Live<C>) {
-        self.idle.push(Idle::new(conn));
+    pub(crate) fn store(&self, conn: Live<C>) -> Result<(), PushError<Idle<C>>> {
+        if let Err(err) = self.idle.push(Idle::new(conn)) {
+            self.idle_push_error_count.fetch_add(1, Ordering::Relaxed);
+            return Err(err);
+        }
+        Ok(())
     }
 
     /// Get the longest-idle connection from the queue.
-    pub fn get(&self) -> Option<Live<C>> {
+    pub(crate) fn get(&self) -> Option<Live<C>> {
         self.idle.pop().ok().map(|Idle { conn, .. }| conn)
     }
 
     /// Increment the connection count without pushing a connection into the
     /// queue.
     #[inline(always)]
-    pub fn increment(&self) {
+    pub(crate) fn increment(&self) {
         self.total_count.fetch_add(1, Ordering::SeqCst);
     }
 
     /// Decrement the connection count
     #[inline(always)]
-    pub fn decrement(&self) {
+    pub(crate) fn decrement(&self) {
         self.total_count.fetch_sub(1, Ordering::SeqCst);
         // this is commented out because it was cuasing an overflow. it's probably important that
         // this is actually run
@@ -145,7 +157,7 @@ impl<C: Send> Queue<C> {
     /// Increment the total number of connections safely, with guarantees that we won't increment
     /// past `max`. This does block until max is reached, so don't pass a huge max size and expect
     /// it to return quickly.
-    pub fn safe_increment(&self, max: usize) -> Option<()> {
+    pub(crate) fn safe_increment(&self, max: usize) -> Option<()> {
         let mut curr_count = self.total();
         while curr_count < max {
             match self.total_count.compare_exchange(
@@ -176,7 +188,7 @@ mod tests {
 
     #[test]
     fn new_conn() {
-        let conns = Queue::new();
+        let conns = Queue::new(1);
         assert_eq!(conns.idle(), 0);
         assert_eq!(conns.total(), 0);
         conns.new_conn(Live::new(()));
@@ -185,18 +197,19 @@ mod tests {
     }
 
     #[test]
-    fn store() {
-        let conns = Queue::new();
+    fn store() -> Result<(), crossbeam_queue::PushError<Idle<()>>> {
+        let conns = Queue::new(1);
         assert_eq!(conns.idle(), 0);
         assert_eq!(conns.total(), 0);
-        conns.store(Live::new(()));
+        conns.store(Live::new(()))?;
         assert_eq!(conns.idle(), 1);
         assert_eq!(conns.total(), 0);
+        Ok(())
     }
 
     #[test]
     fn get() {
-        let conns = Queue::new();
+        let conns = Queue::new(1);
         assert!(conns.get().is_none());
         conns.new_conn(Live::new(()));
         assert!(conns.get().is_some());
@@ -206,7 +219,7 @@ mod tests {
 
     #[test]
     fn increment_and_decrement() {
-        let conns: Queue<()> = Queue::new();
+        let conns: Queue<()> = Queue::new(1);
         assert_eq!(conns.total(), 0);
         assert_eq!(conns.idle(), 0);
         conns.increment();
@@ -215,5 +228,18 @@ mod tests {
         conns.decrement();
         assert_eq!(conns.total(), 0);
         assert_eq!(conns.idle(), 0);
+    }
+
+    #[test]
+    fn store_queue_more_than_the_capacity() {
+        let conns: Queue<()> = Queue::new(1);
+        conns.new_conn(Live::new(()));
+        assert_eq!(1, conns.total());
+        assert_eq!(1, conns.idle());
+        assert_eq!(0, conns.idle_push_error_count());
+        conns.new_conn(Live::new(()));
+        assert_eq!(1, conns.total());
+        assert_eq!(1, conns.idle());
+        assert_eq!(1, conns.idle_push_error_count());
     }
 }


### PR DESCRIPTION
Since the pool size is limitted to the max connections, we can
use crossbeam_queue::ArrayQueue to maintain the idle connections,
which is a bit faster than unbound crossbewam_queue::SegQueue.

The size of the queue is set to twice the size of the max connections,
just to avoid the unnecessary error happens during the connection
push back, even though, technically, it shouldn't happen.  It exposes
the error counter when it happens, so that we can observe the behavior
as well.