### PR TITLE
fix: redis broken connection

### DIFF
--- a/l337-redis/Cargo.toml
+++ b/l337-redis/Cargo.toml
@@ -10,10 +10,13 @@ description = "l337 manager for redis"
 l337 = { version = "0.4", path = ".." }
 futures = "0.3"
 tokio = "0.2"
-redis = "0.14.0"
+redis = "0.16.0"
 async-trait = "0.1.22"
 log = "0.4"
 
 [dev-dependencies]
 # Required for the #[tokio::test] macro
 tokio = { version = "0.2", features = ["rt-core", "macros"] }
+
+[[example]]
+name = "connection-loss"

--- a/l337-redis/examples/connection-loss.rs
+++ b/l337-redis/examples/connection-loss.rs
@@ -1,0 +1,65 @@
+use futures::future::join_all;
+use l337::Pool;
+use l337_redis::RedisConnectionManager;
+use redis::RedisResult;
+use std::{sync::Arc, time::Duration};
+
+async fn blpop_helper(pool: Arc<Pool<RedisConnectionManager>>) -> RedisResult<()> {
+    let mut conn = pool.connection().await.unwrap();
+
+    match redis::cmd("blpop")
+        .arg("random_key")
+        .arg(10)
+        .query_async::<_, ()>(&mut *conn)
+        .await
+    {
+        Ok(_) => println!("Successful blpop"),
+        Err(e) => println!("Unsuccessful blpop: {:?}", e),
+    };
+
+    Ok(())
+}
+
+async fn ping_helper(pool: Arc<Pool<RedisConnectionManager>>) -> RedisResult<()> {
+    match pool.connection().await {
+        Ok(mut conn) => {
+            match redis::cmd("PING").query_async::<_, ()>(&mut *conn).await {
+                Ok(_) => println!("Successful ping"),
+                Err(_) => println!("Unsuccessful ping"),
+            };
+        }
+        Err(_) => println!("could not grab connection from pool"),
+    };
+
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> RedisResult<()> {
+    let mngr = RedisConnectionManager::new("redis://redis:6379/0").unwrap();
+    let config = Default::default();
+    let pool = Pool::new(mngr, config).await.unwrap();
+
+    let pool_arc = Arc::new(pool);
+
+    let blpop_pool = Arc::clone(&pool_arc);
+    tokio::spawn(async move {
+        let mut blpop_futures = vec![];
+        println!("Spawning {} blpop commands", blpop_pool.max_conns());
+        for _ in std::usize::MIN..blpop_pool.max_conns() {
+            blpop_futures.push(blpop_helper(Arc::clone(&blpop_pool)));
+        }
+        join_all(blpop_futures).await;
+        println!("Finished all blpop commands");
+    });
+
+    tokio::time::delay_for(Duration::from_millis(100)).await;
+
+    println!("Attempting to start pinging...");
+    let ping_pool = Arc::clone(&pool_arc);
+    let mut interval = tokio::time::interval(Duration::from_millis(100));
+    loop {
+        interval.tick().await;
+        ping_helper(Arc::clone(&ping_pool)).await;
+    }
+}

--- a/l337-redis/src/lib.rs
+++ b/l337-redis/src/lib.rs
@@ -177,7 +177,7 @@ impl l337::ManageConnection for RedisConnectionManager {
         debug!("connect: try redis connection");
         let (connection, future) = self
             .client
-            .get_multiplexed_async_connection()
+            .create_multiplexed_tokio_connection()
             .await
             .map_err(l337::Error::External)?;
 


### PR DESCRIPTION
Our current version of l337-redis hangs when the connection breaks (with
a FIN for example). Upgrading the redis crate resolves the issue. This
PR also includes an example reproduction case:

1. `docker-compose up -d`
2. `cargo run --example connection-loss`
3. Wait until a "Attempting to start pinging..." message appears
4. Kill redis with `docker kill`
5. Will see `blpop` commands fail and will also be unable to grab
connection from pool for ping commands
6. `docker-compose up -d` to start redis again
7. Notice pings are now successful