### PR TITLE
fix: update redis version

### DIFF
--- a/l337-redis/Cargo.toml
+++ b/l337-redis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "l337-redis"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Jonathon Sheffield <samsmug@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -10,7 +10,7 @@ description = "l337 manager for redis"
 l337 = { version = "0.4", path = ".." }
 futures = "0.3"
 tokio = "0.2"
-redis = "0.16.0"
+redis = "0.16"
 async-trait = "0.1.22"
 log = "0.4"
 


### PR DESCRIPTION
Update redis from from 0.16.0 to 0.16 so we can use commits on 0.16.1-alpha.0, which fixes an authentication issue.