### PR TITLE
update: redis crate upgrade

### DIFF
--- a/l337-redis/Cargo.toml
+++ b/l337-redis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "l337-redis"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["Jonathon Sheffield <samsmug@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -10,7 +10,7 @@ description = "l337 manager for redis"
 l337 = { version = "0.4", path = ".." }
 futures = "0.3"
 tokio = "0.2"
-redis = "0.16"
+redis = "0.17"
 async-trait = "0.1.22"
 log = "0.4"
 


### PR DESCRIPTION
The redis crate has been updated to 0.17.0. This includes a broken pipe
fix.