### PR TITLE
Upgrade tokio to 1.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker: # use the docker executor type; machine and macos executors are also supported
-      - image: circleci/rust:1.40
+      - image: circleci/rust:1.48
       - image: redis:4.0.1
         name: redis
       - image: "sfackler/rust-postgres-test:4"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # 0.7.0
 
+- Meta
+    - Update MSRV to 1.48
+
 - l337
     - Upgrade to tokio 1.x
 - l337-redis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# 0.7.0
+
+- l337
+    - Upgrade to tokio 1.x
+- l337-redis
+    - Upgrade to tokio 1.x
+    - Upgrade to redis 0.20
+- l337-postgres
+    - Upgrade to tokio 1.x
+    - Upgrade to tokio-postgres 0.7

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "l337"
-version = "0.4.5"
+version = "0.7.0"
 authors = ["Jonathon Sheffield <samsmug@gmail.com>",
            "Joe Wilm <joe@jwilm.com>",
            "keith Noguchi <keith@onesignal.com>"]
@@ -10,7 +10,7 @@ edition = "2018"
 
 [dependencies]
 futures = "0.3"
-tokio = { version = "0.2.11", features = ["rt-core", "time", "macros"] }
+tokio = { version = "1", features = ["rt", "time", "macros"] }
 crossbeam-queue = "0.2"
 failure = "0.1.2"
 log = "0.4"

--- a/l337-postgres/Cargo.toml
+++ b/l337-postgres/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "l337-postgres"
-version = "0.4.1"
+version = "0.7.0"
 authors = ["Jonathon Sheffield <samsmug@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "l337 manager for tokio-postgres"
 
 [dependencies]
-l337 = { version = "0.4", path = ".." }
+l337 = { version = "0.7", path = ".." }
 futures = "0.3"
-tokio = "0.2"
-tokio-postgres = "0.5.1"
+tokio = "1"
+tokio-postgres = "0.7"
 log = "0.4.8"
 async-trait = "0.1.22"
 
 [dev-dependencies]
-tokio = { version = "0.2", features = ["macros"] }
+tokio = { version = "1", features = ["macros"] }

--- a/l337-postgres/src/lib.rs
+++ b/l337-postgres/src/lib.rs
@@ -208,7 +208,7 @@ mod tests {
     use super::*;
     use l337::{Config, Pool};
     use std::time::Duration;
-    use tokio::time::delay_for;
+    use tokio::time::sleep;
 
     #[tokio::test]
     async fn it_works() {
@@ -252,7 +252,7 @@ mod tests {
                 assert_eq!(1, row.get(0));
             }
 
-            delay_for(Duration::from_secs(5)).await;
+            sleep(Duration::from_secs(5)).await;
 
             conn
         };
@@ -266,7 +266,7 @@ mod tests {
                 assert_eq!(2, row.get(0));
             }
 
-            delay_for(Duration::from_secs(5)).await;
+            sleep(Duration::from_secs(5)).await;
 
             conn
         };
@@ -300,7 +300,7 @@ mod tests {
         // This delay is required to ensure that the connection is returned to
         // the pool after Drop runs. Because Drop spawns a future that returns
         // the connection to the pool.
-        delay_for(Duration::from_millis(500)).await;
+        sleep(Duration::from_millis(500)).await;
 
         let q2 = async {
             let conn = pool.connection().await.unwrap();

--- a/l337-redis/Cargo.toml
+++ b/l337-redis/Cargo.toml
@@ -1,22 +1,22 @@
 [package]
 name = "l337-redis"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Jonathon Sheffield <samsmug@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "l337 manager for redis"
 
 [dependencies]
-l337 = { version = "0.4", path = ".." }
+l337 = { version = "0.7", path = ".." }
 futures = "0.3"
-tokio = "0.2"
-redis = "0.17"
+tokio = "1"
+redis = { version = "0.20", features = ["aio", "tokio-comp"] }
 async-trait = "0.1.22"
 log = "0.4"
 
 [dev-dependencies]
 # Required for the #[tokio::test] macro
-tokio = { version = "0.2", features = ["rt-core", "macros"] }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
 
 [[example]]
 name = "connection-loss"

--- a/l337-redis/examples/connection-loss.rs
+++ b/l337-redis/examples/connection-loss.rs
@@ -53,7 +53,7 @@ async fn main() -> RedisResult<()> {
         println!("Finished all blpop commands");
     });
 
-    tokio::time::delay_for(Duration::from_millis(100)).await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
 
     println!("Attempting to start pinging...");
     let ping_pool = Arc::clone(&pool_arc);

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -135,7 +135,7 @@ mod tests {
     use crate::tests::DummyManager;
     use crate::Config;
     use std::time::Duration;
-    use tokio::time::delay_for;
+    use tokio::time::sleep;
 
     #[tokio::test]
     async fn conn_pushes_back_into_pool_after_drop() {
@@ -152,7 +152,7 @@ mod tests {
 
         // The connection is added back to the pool asynchronously, so we need
         // to wait for the future to finish.
-        delay_for(Duration::from_secs(1)).await;
+        sleep(Duration::from_secs(1)).await;
 
         assert_eq!(pool.idle_conns(), 2);
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,11 +22,11 @@ pub enum Error<E: failure::Fail> {
     External(E),
 }
 
-impl<E> From<tokio::time::Elapsed> for Error<E>
+impl<E> From<tokio::time::error::Elapsed> for Error<E>
 where
     E: failure::Fail,
 {
-    fn from(_: tokio::time::Elapsed) -> Self {
+    fn from(_: tokio::time::error::Elapsed) -> Self {
         Self::Internal(InternalError::TimedOut)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,7 +207,7 @@ impl<C: ManageConnection + Send> Pool<C> {
                     // problematic because tokio's scheduler will allow the task
                     // to block up the runtime, so it is useful to add some
                     // delays to loops to allow other futures to be polled.
-                    tokio::time::delay_for(Duration::from_millis(100)).await;
+                    tokio::time::sleep(Duration::from_millis(100)).await;
                 }
             }
         }
@@ -343,7 +343,7 @@ impl<C: ManageConnection + Send> Pool<C> {
                             err
                         );
                         // TODO: make this use config
-                        time::delay_for(Duration::from_secs(1)).await;
+                        time::sleep(Duration::from_secs(1)).await;
                     }
                 }
             }


### PR DESCRIPTION
Tokio 1.x has a very strong backwards compatibility guarantee and most async
rust libraries now support it.  We should adopt here to get new features and
bug fixes.