### PR TITLE
Tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.8.0
+
+- Replace `log` events with `tracing` spans
+
 # 0.7.0
 
 - Meta

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "l337"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Jonathon Sheffield <samsmug@gmail.com>",
            "Joe Wilm <joe@jwilm.com>",
            "keith Noguchi <keith@onesignal.com>"]
@@ -13,7 +13,8 @@ futures = "0.3"
 tokio = { version = "1", features = ["rt", "time", "macros"] }
 crossbeam-queue = "0.2"
 failure = "0.1.2"
-log = "0.4"
+tracing = "0.1"
+tracing-futures = "0.2"
 async-trait = "0.1.22"
 
 [workspace]

--- a/l337-postgres/Cargo.toml
+++ b/l337-postgres/Cargo.toml
@@ -1,18 +1,19 @@
 [package]
 name = "l337-postgres"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Jonathon Sheffield <samsmug@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "l337 manager for tokio-postgres"
 
 [dependencies]
-l337 = { version = "0.7", path = ".." }
+l337 = { version = "0.8", path = ".." }
 futures = "0.3"
 tokio = "1"
 tokio-postgres = "0.7"
-log = "0.4.8"
 async-trait = "0.1.22"
+tracing = "0.1"
+tracing-futures = "0.2"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros"] }

--- a/l337-postgres/src/lib.rs
+++ b/l337-postgres/src/lib.rs
@@ -1,16 +1,7 @@
 //! Postgres adapater for l3-37 pool
 // #![deny(missing_docs, missing_debug_implementations)]
 
-extern crate futures;
-pub extern crate l337;
-extern crate tokio;
-pub extern crate tokio_postgres;
-
-#[macro_use]
-extern crate log;
-#[macro_use]
-extern crate async_trait;
-
+use async_trait::async_trait;
 use futures::{channel::oneshot, prelude::*};
 use std::{
     convert::{AsMut, AsRef},

--- a/l337-redis/Cargo.toml
+++ b/l337-redis/Cargo.toml
@@ -1,18 +1,19 @@
 [package]
 name = "l337-redis"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Jonathon Sheffield <samsmug@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "l337 manager for redis"
 
 [dependencies]
-l337 = { version = "0.7", path = ".." }
+l337 = { version = "0.8", path = ".." }
 futures = "0.3"
 tokio = "1"
 redis = { version = "0.20", features = ["aio", "tokio-comp"] }
 async-trait = "0.1.22"
-log = "0.4"
+tracing = "0.1"
+tracing-futures = "0.2"
 
 [dev-dependencies]
 # Required for the #[tokio::test] macro

--- a/l337-redis/src/lib.rs
+++ b/l337-redis/src/lib.rs
@@ -1,15 +1,7 @@
 //! Postgres adapater for l3-37 pool
 // #![deny(missing_docs, missing_debug_implementations)]
 
-extern crate futures;
-pub extern crate l337;
-extern crate redis;
-extern crate tokio;
-#[macro_use]
-extern crate async_trait;
-#[macro_use]
-extern crate log;
-
+use async_trait::async_trait;
 use futures::{
     channel::oneshot,
     future::{self, BoxFuture},

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,5 @@
+use failure::Fail;
+
 #[derive(Debug, Fail)]
 pub enum InternalError {
     #[fail(display = "unknown error: {}", _0)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,16 +43,6 @@
 //!
 //! Any connection type that implements the `ManageConnection` trait can be used with this libary.
 
-extern crate crossbeam_queue;
-extern crate futures;
-extern crate tokio;
-#[macro_use]
-extern crate failure;
-#[macro_use]
-extern crate log;
-#[macro_use]
-extern crate async_trait;
-
 mod config;
 mod conn;
 mod error;
@@ -374,6 +364,8 @@ impl<C: ManageConnection + Send> Pool<C> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use async_trait::async_trait;
+    use failure::Fail;
     use std::sync::{atomic::*, Arc};
     use std::time::Duration;
     use tokio::time::timeout;

--- a/src/manage_connection.rs
+++ b/src/manage_connection.rs
@@ -22,6 +22,7 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 use crate::Error as L337Error;
+use async_trait::async_trait;
 
 /// A trait which provides connection-specific functionality.
 #[async_trait]


### PR DESCRIPTION
# Use rust-2018 style macro imports …
These make it more clear where macros are coming from.

# Add tracing spans …
Tracing spans are significantly better than start/end events for tracking in the
timings of events.
