### PR TITLE
fix: swap to thiserror

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "l337"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Jonathon Sheffield <samsmug@gmail.com>",
            "Joe Wilm <joe@jwilm.com>",
            "keith Noguchi <keith@onesignal.com>"]
@@ -12,10 +12,10 @@ edition = "2018"
 futures = "0.3"
 tokio = { version = "1", features = ["rt", "time", "macros"] }
 crossbeam-queue = "0.2"
-failure = "0.1.2"
 tracing = "0.1"
 tracing-futures = "0.2"
 async-trait = "0.1.22"
+thiserror = "1.0.29"
 
 [workspace]
 members = [

--- a/l337-postgres/Cargo.toml
+++ b/l337-postgres/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 description = "l337 manager for tokio-postgres"
 
 [dependencies]
-l337 = { version = "0.8", path = ".." }
+l337 = { version = "0.9", path = ".." }
 futures = "0.3"
 tokio = "1"
 tokio-postgres = "0.7"

--- a/l337-redis/Cargo.toml
+++ b/l337-redis/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 description = "l337 manager for redis"
 
 [dependencies]
-l337 = { version = "0.8", path = ".." }
+l337 = { version = "0.9", path = ".." }
 futures = "0.3"
 tokio = "1"
 redis = { version = "0.20", features = ["aio", "tokio-comp"] }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,32 +1,32 @@
-use failure::Fail;
+use thiserror::Error;
 
-#[derive(Debug, Fail)]
+#[derive(Debug, Error)]
 pub enum InternalError {
-    #[fail(display = "unknown error: {}", _0)]
+    #[error("unknown error: {0}")]
     Other(String),
 
-    #[fail(display = "Tried to get a connection from the pool, but all connections were invalid")]
+    #[error("Tried to get a connection from the pool, but all connections were invalid")]
     AllConnectionsInvalid,
 
-    #[fail(display = "Timed out waiting for a connection to become available")]
+    #[error("Timed out waiting for a connection to become available")]
     TimedOut,
 }
 
 /// Error type returned by this module
-#[derive(Debug, Fail)]
-pub enum Error<E: failure::Fail> {
+#[derive(Debug, Error)]
+pub enum Error<E: std::error::Error> {
     /// Error coming from the connection pooling itself
-    #[fail(display = "l337 internal error: {}", _0)]
-    Internal(InternalError),
+    #[error("l337 internal error")]
+    Internal(#[source] InternalError),
 
     /// Error from the connection manager or the underlying client
-    #[fail(display = "l337 manager error: {}", _0)]
-    External(E),
+    #[error("l337 manager error")]
+    External(#[source] E),
 }
 
 impl<E> From<tokio::time::error::Elapsed> for Error<E>
 where
-    E: failure::Fail,
+    E: std::error::Error,
 {
     fn from(_: tokio::time::error::Elapsed) -> Self {
         Self::Internal(InternalError::TimedOut)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -373,9 +373,9 @@ impl<C: ManageConnection + Send> Pool<C> {
 mod tests {
     use super::*;
     use async_trait::async_trait;
-    use failure::Fail;
     use std::sync::{atomic::*, Arc};
     use std::time::Duration;
+    use thiserror::Error;
     use tokio::time::timeout;
 
     #[derive(Debug)]
@@ -390,8 +390,8 @@ mod tests {
         broken: bool,
     }
 
-    #[derive(Debug, Fail)]
-    #[fail(display = "DummyError")]
+    #[derive(Debug, Error)]
+    #[error("DummyError")]
     pub struct DummyError;
 
     impl DummyManager {

--- a/src/manage_connection.rs
+++ b/src/manage_connection.rs
@@ -31,7 +31,7 @@ pub trait ManageConnection: Send + Sync + 'static {
     type Connection: Send + 'static;
 
     /// The error type returned by `Connection`s.
-    type Error: failure::Fail;
+    type Error: std::error::Error + Send;
 
     /// Attempts to create a new connection.
     ///


### PR DESCRIPTION
We swap to `thiserror` to remove the dependency on `failure`.