### PR TITLE
chore: bump version for redis/postgres

### DIFF
--- a/l337-postgres/Cargo.toml
+++ b/l337-postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "l337-postgres"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Jonathon Sheffield <samsmug@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/l337-redis/Cargo.toml
+++ b/l337-redis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "l337-redis"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Jonathon Sheffield <samsmug@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
We need to upgrade these to 0.9 as well